### PR TITLE
Replica: Shrink container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     nano \
   && (curl -sL https://deb.nodesource.com/setup_20.x | bash -) \
   && apt-get install -y --no-install-recommends nodejs \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/ruby
@@ -34,9 +35,7 @@ RUN gem install bundler -v 2.5.6 --no-doc
 # Install the latest and active gem dependencies and re-run
 # the appropriate commands to handle installs.
 COPY --chown=postal Gemfile Gemfile.lock ./
-RUN bundle install \
-    && rm -rf /usr/local/bundle/cache/*.gem \
-    && rm -rf /opt/postal/.bundle/cache
+RUN bundle install
 
 # Copy the application (and set permissions)
 COPY ./docker/wait-for.sh /docker-entrypoint.sh


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3338

**Autore originale:** @SiebeVE
**Branch originale:** `feature/shrink-container-size`
**Repository originale:** SiebeVE/postal

---

Currently the container size of the postal container (uncompressed) is around 1.2GB.

This MR is the starting point to lower the size of the container.
I've used https://github.com/wagoodman/dive to see where we can improve things.

My knowledge in Ruby is lacking, so maybe there are other points that can be improved.

This container is untested and should first be checked if all things still run like they are supposed to.