### PR TITLE
Replica: fix: typo in process logging

### DIFF
--- a/app/lib/worker/process.rb
+++ b/app/lib/worker/process.rb
@@ -202,7 +202,7 @@ module Worker
           logger.info "stopping tasks thread"
           ActiveRecord::Base.connection_pool.with_connection do
             if WorkerRole.release(:tasks)
-              logger.info "releasesd tasks role"
+              logger.info "released tasks role"
             end
           end
         end


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3212

**Autore originale:** @melledouwsma
**Branch originale:** `patch-1`
**Repository originale:** melledouwsma/postal

---

Minor spelling fix, would resolve #3051