### PR TITLE
Replica: fix(doc): fix invalid yaml syntax

### DIFF
--- a/doc/config/yaml.yml
+++ b/doc/config/yaml.yml
@@ -102,7 +102,7 @@ smtp_server:
   # The default port the SMTP server should listen on unless overriden by the PORT environment variable
   default_port: 25
   # The default bind address the SMTP server should listen on unless overriden by the BIND_ADDRESS environment variable
-  default_bind_address: ::
+  default_bind_address: "::"
   # The default port for the SMTP server health server to listen on
   default_health_server_port: 9091
   # The default bind address for the SMTP server health server to listen on


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3050

**Autore originale:** @dumbasPL
**Branch originale:** `patch-1`
**Repository originale:** dumbasPL/postal

---

yaml values containing `:` need to be wrapped in quotes

The old example config would crash the app