### PR TITLE
Replica: Add message token for bounces

### DIFF
--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -142,10 +142,10 @@ class SMTPSender < BaseSender
     # If the domain has a valid custom return path configured, return
     # that.
     if message.domain.return_path_status == "OK"
-      return "#{message.server.token}@#{message.domain.return_path_domain}"
+      return "#{message.server.token}+#{message.token}@#{message.domain.return_path_domain}"
     end
 
-    "#{message.server.token}@#{Postal::Config.dns.return_path_domain}"
+    "#{message.server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}"
   end
 
   # Return the RCPT TO to use for the given message in this sending session

--- a/doc/config/yaml.yml
+++ b/doc/config/yaml.yml
@@ -23,6 +23,8 @@ postal:
   use_local_ns_for_domain_verification: false
   # Append a Resend-Sender header to all outgoing e-mails
   use_resent_sender_header: true
+  # Use message tags when assigning bounces to their corresponding messages
+  use_message_tags_for_bounces: false
   # Path to the private key used for signing
   signing_key_path: $config-file-root/signing.key
   # An array of SMTP relays in the format of smtp://host:port

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -66,6 +66,11 @@ module Postal
         default true
       end
 
+      boolean :use_message_tags_for_bounces do
+        description "Use message tags when assigning bounces to their corresponding messages"
+        default false
+      end
+
       string :signing_key_path do
         description "Path to the private key used for signing"
         default "$config-file-root/signing.key"

--- a/spec/senders/smtp_sender_spec.rb
+++ b/spec/senders/smtp_sender_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SMTPSender do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
               kind_of(String),
-              "#{server.token}@#{domain.return_path_domain}",
+              "#{server.token}+#{message.token}@#{domain.return_path_domain}",
               ["john@example.com"]
             )
           end
@@ -274,7 +274,7 @@ RSpec.describe SMTPSender do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
               kind_of(String),
-              "#{server.token}@#{Postal::Config.dns.return_path_domain}",
+              "#{server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}",
               ["john@example.com"]
             )
           end
@@ -308,7 +308,7 @@ RSpec.describe SMTPSender do
           it "adds the resent-sender header" do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
-              "Resent-Sender: #{server.token}@#{Postal::Config.dns.return_path_domain}\r\n#{message.raw_message}",
+              "Resent-Sender: #{server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}\r\n#{message.raw_message}",
               kind_of(String),
               kind_of(Array)
             )


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3036

**Autore originale:** @schueffi
**Branch originale:** `add_message_token_for_bounces`
**Repository originale:** schueffi/postal

---

Similar to pull request 2855 ( https://github.com/postalserver/postal/pull/2855 ), the message token will be inserted into MAIL FROM (i.e. for the return path for bounces).
In addition, there is a new configuration option (default disable the new feature), to look for this newly generated message tag when a bounce message comes in. If no tag is found, or the new lookup feature is disabled, then the old (backwards compatible) lookup for the X-Postal-MsgID header will be utilized to search for the corresponding referenced mail.

Using an individual mail address is way more stable than inserting a header into outgoing mails, and relaying on the existence of this header in incoming bounce messages. A lot of "real world" MTAs out there strip additional headers or compose new bounce mails not including the X-Postal-MsgID header. All those incoming bounces can be easily assigned to their corresponding outgoing mails by their individual message tag as part of the bounce mail address.