### PR TITLE
Replica: Add support for configurable DKIM key sizes

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -82,7 +82,7 @@ class Domain < ApplicationRecord
   end
 
   def generate_dkim_key
-    self.dkim_private_key = OpenSSL::PKey::RSA.new(1024).to_s
+    self.dkim_private_key = OpenSSL::PKey::RSA.new(Postal::Config.postal.default_dkim_key_size).to_s
   end
 
   def dkim_key

--- a/doc/config/yaml.yml
+++ b/doc/config/yaml.yml
@@ -23,6 +23,8 @@ postal:
   use_local_ns_for_domain_verification: false
   # Append a Resend-Sender header to all outgoing e-mails
   use_resent_sender_header: true
+  # The default size for new DKIM keys
+  default_dkim_key_size: 1024
   # Path to the private key used for signing
   signing_key_path: $config-file-root/signing.key
   # An array of SMTP relays in the format of smtp://host:port

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -66,6 +66,11 @@ module Postal
         default true
       end
 
+      integer :default_dkim_key_size do
+        description "The default size for new DKIM keys"
+        default 1024
+      end
+
       string :signing_key_path do
         description "Path to the private key used for signing"
         default "$config-file-root/signing.key"


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3030

**Autore originale:** @schueffi
**Branch originale:** `add_configurable_dkim_keysize`
**Repository originale:** schueffi/postal

---

In order to support DKIM RSA key sizes other than 1024, a new config variable default_dkim_key_size has been introduced. The default value still is 1024 to make it backwards compatible, but it now supports e.g. 2048 or 4096 bit keys as well.

At the time of this commit (mid-2024), having 2048 bit keys is recommended by the National Institute of Standards and Technology (NIST)