### PR TITLE
Replica: feat(smtp): add config option to disable sending email via ipv6

### DIFF
--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -177,8 +177,8 @@ class SMTPSender < BaseSender
   # @param endpoint [SMTPClient::Endpoint]
   # @return [Boolean]
   def connect_to_endpoint(endpoint, allow_ssl: true)
-    if @source_ip_address && @source_ip_address.ipv6.blank? && endpoint.ipv6?
-      # Don't try to use IPv6 if the IP address we're sending from doesn't support it.
+    if (@source_ip_address && @source_ip_address.ipv6.blank? && endpoint.ipv6?) || Postal::Config.smtp.disable_ipv6
+      # Don't try to use IPv6 if the IP address we're sending from doesn't support it or if it's disabled in the config.
       return false
     end
 

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -413,6 +413,11 @@ module Postal
         description "The e-mail to use as the from address outgoing emails from Postal"
         default "postal@example.com"
       end
+
+      boolean :disable_ipv6 do
+        description "Disalbles sending emails via IPv6, only IPv4 will be used"
+        default false
+      end
     end
 
     group :rails do


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3009

**Autore originale:** @QuinnDamerell
**Branch originale:** `disable-ipv6-sending`
**Repository originale:** QuinnDamerell/postal

---

This quick feature adds a config flag allowing users to disable emailing via IPv6. 

The inspiration behind this is a scenario I'm facing; I have a VPS with IPv4 and IPv6, but the IPv6 address is deny listed for some email hosts (like Gmail). I tried some workaround, like disabling IPv6 on the VM and disabling the DNS resolver from returning AAAA records, but this was the best and most reliable fix.

I'm sure I'm not the first user to hit an issue like this, so this would be helpful for everyone!