### PR TITLE
feat: Feature/add domain throttles

### DIFF
--- a/app/assets/stylesheets/application/components/_throttle_list.scss
+++ b/app/assets/stylesheets/application/components/_throttle_list.scss
@@ -1,0 +1,54 @@
+.throttleList {
+  border-radius:4px;
+  overflow:hidden;
+  box-shadow:0 0 10px rgba(0,0,0,0.2);
+}
+
+.throttleList__item {
+  background:#fff;
+  padding:15px;
+  display:flex;
+  align-items: center;
+}
+.throttleList__item:nth-child(even) {
+  background:none;
+}
+
+.throttleList__item + .throttleList__item {
+  border-top:1px solid lighten(#ccd4e0, 10%);
+}
+
+.throttleList__left {
+  flex: 1 1 auto;
+}
+
+.throttleList__right {
+  flex: 0 0 auto;
+  text-align: right;
+  margin-right: 20px;
+}
+
+.throttleList__actions {
+  flex: 0 0 auto;
+}
+
+.throttleList__domain {
+  font-weight:600;
+  margin-bottom:5px;
+  font-size: 14px;
+}
+
+.throttleList__reason {
+  color:#999;
+  font-size: 12px;
+}
+
+.throttleList__timestamp {
+  color:#999;
+  font-size:12px;
+}
+
+.throttleList__remaining {
+  margin-top: 5px;
+}
+

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -147,6 +147,23 @@ class MessagesController < ApplicationController
     @suppressions = @server.message_db.suppression_list.all_with_pagination(params[:page])
   end
 
+  def throttled_domains
+    @throttled_domains = @server.domain_throttles.active.order(throttled_until: :asc)
+  end
+
+  def remove_throttled_domain
+    throttle = @server.domain_throttles.find_by(id: params[:id])
+    if throttle
+      domain = throttle.domain
+      throttle.destroy
+      redirect_to throttled_domains_organization_server_messages_path(organization, @server),
+                  notice: "Throttle for #{domain} has been removed."
+    else
+      redirect_to throttled_domains_organization_server_messages_path(organization, @server),
+                  alert: "Throttle not found."
+    end
+  end
+
   def activity
     @entries = @message.activity_entries
   end

--- a/app/lib/message_dequeuer/outgoing_message_processor.rb
+++ b/app/lib/message_dequeuer/outgoing_message_processor.rb
@@ -10,6 +10,7 @@ module MessageDequeuer
         add_tag
         hold_if_credential_is_set_to_hold
         hold_if_recipient_on_suppression_list
+        skip_if_domain_throttled
         parse_content
         inspect_message
         fail_if_spam
@@ -18,6 +19,7 @@ module MessageDequeuer
         increment_live_stats
         hold_if_server_development_mode
         send_message_to_sender
+        apply_domain_throttle_if_required
         add_recipient_to_suppression_list_on_too_many_hard_fails
         remove_recipient_from_suppression_list_on_success
         log_sender_result
@@ -73,6 +75,25 @@ module MessageDequeuer
       log "recipient is on the suppression list, holding"
       create_delivery "Held", details: "Recipient (#{queued_message.message.rcpt_to}) is on the suppression list (reason: #{sl['reason']})"
       remove_from_queue
+      stop_processing
+    end
+
+    def skip_if_domain_throttled
+      return if queued_message.manual?
+
+      domain = queued_message.message.recipient_domain
+      return unless domain
+
+      throttle = DomainThrottle.throttled?(queued_message.server, domain)
+      return unless throttle
+
+      # Requeue the message to retry after the throttle expires
+      retry_seconds = throttle.remaining_seconds + 10
+      queued_message.retry_later(retry_seconds)
+      log "domain #{domain} is throttled, requeuing for later",
+          throttled_until: throttle.throttled_until,
+          retry_after: queued_message.retry_after,
+          reason: throttle.reason
       stop_processing
     end
 
@@ -158,6 +179,51 @@ module MessageDequeuer
       return unless @result.connect_error
 
       @state.send_result = @result
+    end
+
+    def apply_domain_throttle_if_required
+      return unless @result
+      return unless @result.domain_throttle_required
+
+      domain = queued_message.message.recipient_domain
+      return unless domain
+
+      duration = @result.domain_throttle_duration || DomainThrottle::DEFAULT_THROTTLE_DURATION
+      reason = @result.output.to_s.truncate(255)
+
+      # Create or update the throttle for this domain
+      throttle = DomainThrottle.apply(
+        queued_message.server,
+        domain,
+        duration: duration,
+        reason: reason
+      )
+
+      log "applied domain throttle",
+          domain: domain,
+          duration: duration,
+          throttled_until: throttle.throttled_until,
+          reason: reason
+
+      # Update retry_after for all queued messages to the same domain on this server
+      # This prevents other workers from attempting to send to the throttled domain
+      throttle_all_queued_messages_for_domain(domain, throttle.throttled_until)
+    end
+
+    def throttle_all_queued_messages_for_domain(domain, throttled_until)
+      retry_after = throttled_until + 10.seconds
+
+      # Update all queued messages for this domain that don't already have a later retry_after
+      updated_count = QueuedMessage.where(server_id: queued_message.server_id, domain: domain)
+                                   .where("retry_after IS NULL OR retry_after < ?", retry_after)
+                                   .where.not(id: queued_message.id)
+                                   .update_all(retry_after: retry_after)
+
+      if updated_count > 0
+        log "throttled #{updated_count} additional queued messages for domain",
+            domain: domain,
+            retry_after: retry_after
+      end
     end
 
     def add_recipient_to_suppression_list_on_too_many_hard_fails

--- a/app/models/domain_throttle.rb
+++ b/app/models/domain_throttle.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: domain_throttles
+#
+#  id              :integer          not null, primary key
+#  server_id       :integer          not null
+#  domain          :string(255)      not null
+#  throttled_until :datetime         not null
+#  reason          :string(255)
+#  created_at      :datetime
+#  updated_at      :datetime
+#
+# Indexes
+#
+#  index_domain_throttles_on_server_id_and_domain  (server_id, domain) UNIQUE
+#  index_domain_throttles_on_throttled_until       (throttled_until)
+#
+
+class DomainThrottle < ApplicationRecord
+
+  # Default throttle duration in seconds (5 minutes)
+  DEFAULT_THROTTLE_DURATION = 300
+
+  # Maximum throttle duration in seconds (30 minutes)
+  MAX_THROTTLE_DURATION = 1800
+
+  belongs_to :server
+
+  validates :domain, presence: true
+  validates :throttled_until, presence: true
+  validates :domain, uniqueness: { scope: :server_id }
+
+  scope :active, -> { where("throttled_until > ?", Time.current) }
+  scope :expired, -> { where("throttled_until <= ?", Time.current) }
+
+  # Check if a domain is currently throttled for a given server
+  #
+  # @param server [Server] the server to check
+  # @param domain [String] the domain to check
+  # @return [DomainThrottle, nil] the throttle record if active, nil otherwise
+  def self.throttled?(server, domain)
+    active.find_by(server: server, domain: domain.to_s.downcase)
+  end
+
+  # Apply or extend a throttle for a domain
+  #
+  # @param server [Server] the server to throttle for
+  # @param domain [String] the domain to throttle
+  # @param duration [Integer] duration in seconds
+  # @param reason [String] the reason for throttling (e.g., the SMTP error message)
+  # @return [DomainThrottle] the created or updated throttle record
+  def self.apply(server, domain, duration: DEFAULT_THROTTLE_DURATION, reason: nil)
+    normalized_domain = domain.to_s.downcase
+    throttle = find_or_initialize_by(server: server, domain: normalized_domain)
+
+    # If already throttled, extend the duration with exponential backoff
+    if throttle.persisted? && throttle.throttled_until > Time.current
+      # Double the remaining time, but cap at MAX_THROTTLE_DURATION
+      remaining = throttle.throttled_until - Time.current
+      new_duration = [(remaining * 2).to_i, duration, MAX_THROTTLE_DURATION].min
+      duration = [new_duration, duration].max
+    end
+
+    throttle.throttled_until = Time.current + duration.seconds
+    throttle.reason = reason.to_s.truncate(255) if reason.present?
+    throttle.save!
+    throttle
+  end
+
+  # Remove expired throttles from the database
+  #
+  # @return [Integer] the number of records deleted
+  def self.cleanup_expired
+    expired.delete_all
+  end
+
+  # Get the remaining throttle time in seconds
+  #
+  # @return [Integer] seconds remaining, or 0 if expired
+  def remaining_seconds
+    return 0 if throttled_until <= Time.current
+
+    (throttled_until - Time.current).to_i
+  end
+
+  # Check if this throttle is still active
+  #
+  # @return [Boolean]
+  def active?
+    throttled_until > Time.current
+  end
+
+end
+

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -63,6 +63,7 @@ class Server < ApplicationRecord
   has_many :address_endpoints, dependent: :destroy
   has_many :routes, dependent: :destroy
   has_many :queued_messages, dependent: :delete_all
+  has_many :domain_throttles, dependent: :delete_all
   has_many :webhooks, dependent: :destroy
   has_many :webhook_requests, dependent: :destroy
   has_many :track_domains, dependent: :destroy

--- a/app/scheduled_tasks/prune_domain_throttles_scheduled_task.rb
+++ b/app/scheduled_tasks/prune_domain_throttles_scheduled_task.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PruneDomainThrottlesScheduledTask < ApplicationScheduledTask
+
+  def call
+    deleted_count = DomainThrottle.cleanup_expired
+    if deleted_count > 0
+      logger.info "Pruned #{deleted_count} expired domain throttles"
+    end
+  end
+
+  def self.next_run_after
+    # Run every 15 minutes
+    15.minutes.from_now
+  end
+
+end
+

--- a/app/senders/send_result.rb
+++ b/app/senders/send_result.rb
@@ -11,6 +11,8 @@ class SendResult
   attr_accessor :log_id
   attr_accessor :time
   attr_accessor :suppress_bounce
+  attr_accessor :domain_throttle_required
+  attr_accessor :domain_throttle_duration
 
   def initialize
     @details = ""

--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -107,6 +107,13 @@ class SMTPSender < BaseSender
       else
         r.retry = true
       end
+
+      # Check for rate limiting responses (451 too many messages, slow down, etc.)
+      if requires_domain_throttle?(e.message)
+        r.domain_throttle_required = true
+        r.domain_throttle_duration = extract_throttle_duration(e.message)
+        logger.info "Domain throttling required: #{r.domain_throttle_duration} seconds"
+      end
     end
   rescue Net::SMTPFatalError => e
     logger.error "#{e.class}: #{e.message}"
@@ -234,6 +241,46 @@ class SMTPSender < BaseSender
 
   def logger
     @logger ||= Postal.logger.create_tagged_logger(log_id: @log_id)
+  end
+
+  # Check if the error message indicates that domain-level throttling is required
+  #
+  # @param message [String] the SMTP error message
+  # @return [Boolean]
+  def requires_domain_throttle?(message)
+    return false if message.blank?
+
+    # Match common patterns for rate limiting responses
+    # 451 is the standard code for "try again later"
+    throttle_patterns = [
+      /\b451\b.*\b(too many|rate limit|slow down|try again later|temporarily deferred)/i,
+      /\b(too many messages|too many connections|rate limit|sending rate|slow down)\b/i,
+      /\b(temporarily rejected|temporarily deferred|try again later)\b.*\b(rate|limit|too many)/i
+    ]
+
+    throttle_patterns.any? { |pattern| message.match?(pattern) }
+  end
+
+  # Extract throttle duration from SMTP error message
+  #
+  # @param message [String] the SMTP error message
+  # @return [Integer] duration in seconds (default: 300 = 5 minutes)
+  def extract_throttle_duration(message)
+    default_duration = DomainThrottle::DEFAULT_THROTTLE_DURATION
+
+    return default_duration if message.blank?
+
+    # Try to extract a specific time from the message
+    if message =~ /(\d+)\s*seconds?/i
+      return [::Regexp.last_match(1).to_i + 10, default_duration].max
+    elsif message =~ /(\d+)\s*minutes?/i
+      return [(::Regexp.last_match(1).to_i * 60) + 10, default_duration].max
+    elsif message =~ /(\d+)\s*hours?/i
+      # Cap at max throttle duration for very long delays
+      return [::Regexp.last_match(1).to_i * 3600, DomainThrottle::MAX_THROTTLE_DURATION].min
+    end
+
+    default_duration
   end
 
   class << self

--- a/app/views/messages/_header.html.haml
+++ b/app/views/messages/_header.html.haml
@@ -6,3 +6,4 @@
     %li.navBar__item= link_to "Held", [:held, organization, @server, :messages], :class => ['navBar__link', active_nav == :held ? 'is-active' : '']
     %li.navBar__item= link_to "Send Message", [:new, organization, @server, :message], :class => ['navBar__link', active_nav == :new ? 'is-active' : '']
     %li.navBar__item= link_to "Suppressions", [:suppressions, organization, @server, :messages], :class => ['navBar__link', active_nav == :suppressions ? 'is-active' : '']
+    %li.navBar__item= link_to "Throttled Domains", [:throttled_domains, organization, @server, :messages], :class => ['navBar__link', active_nav == :throttled_domains ? 'is-active' : '']

--- a/app/views/messages/throttled_domains.html.haml
+++ b/app/views/messages/throttled_domains.html.haml
@@ -1,0 +1,42 @@
+- page_title << @server.name
+- page_title << "Messages"
+- page_title << "Throttled Domains"
+= render 'servers/sidebar', :active_server => @server
+= render 'servers/header', :active_nav => :messages
+= render 'header', :active_nav => :throttled_domains
+.pageContent.pageContent--compact
+  - if @throttled_domains.empty?
+    .noData.noData--clean
+      %h2.noData__title No domains are currently throttled.
+      %p.noData__text
+        When a remote mail server responds with a rate limiting error (451), the domain is temporarily
+        throttled to avoid further issues. Active throttles will appear here.
+  - else
+    %p.pageContent__intro.u-margin
+      These domains are currently throttled due to rate limiting responses from their mail servers.
+      Messages to these domains will be held until the throttle expires.
+    %ul.throttleList
+      - @throttled_domains.each do |throttle|
+        %li.throttleList__item
+          .throttleList__left
+            %p.throttleList__domain= throttle.domain
+            %p.throttleList__reason= throttle.reason.present? ? throttle.reason.truncate(100) : "Rate limit exceeded"
+          .throttleList__right
+            %p.throttleList__timestamp
+              Expires #{throttle.throttled_until.to_fs(:long)}
+            %p.throttleList__remaining
+              - remaining = throttle.remaining_seconds
+              - if remaining > 3600
+                %span.label.label--warning= "#{(remaining / 3600).floor}h #{((remaining % 3600) / 60).floor}m remaining"
+              - elsif remaining > 60
+                %span.label.label--warning= "#{(remaining / 60).floor}m #{(remaining % 60).floor}s remaining"
+              - else
+                %span.label.label--positive= "#{remaining}s remaining"
+          .throttleList__actions
+            = link_to "Remove", throttled_domain_organization_server_messages_path(organization, @server, throttle), method: :delete, class: "button button--tiny button--danger", data: { confirm: "Are you sure you want to remove this throttle? Messages to #{throttle.domain} will be sent immediately." }
+
+    %p.u-margin.u-muted
+      %small
+        Throttled domains are automatically removed when the throttle expires.
+        You can manually remove a throttle if you believe the issue has been resolved.
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         post :retry, on: :member
         post :cancel_hold, on: :member
         get :suppressions, on: :collection
+        get :throttled_domains, on: :collection
+        delete "throttled_domains/:id", on: :collection, action: "remove_throttled_domain", as: "throttled_domain"
         delete :remove_from_queue, on: :member
         get :deliveries, on: :member
       end

--- a/db/migrate/20251210000001_create_domain_throttles.rb
+++ b/db/migrate/20251210000001_create_domain_throttles.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateDomainThrottles < ActiveRecord::Migration[7.0]
+
+  def change
+    create_table :domain_throttles, id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci" do |t|
+      t.integer :server_id, null: false
+      t.string :domain, null: false
+      t.datetime :throttled_until, null: false
+      t.string :reason
+      t.timestamps precision: nil
+    end
+
+    add_index :domain_throttles, [:server_id, :domain], unique: true
+    add_index :domain_throttles, :throttled_until
+    add_foreign_key :domain_throttles, :servers
+  end
+
+end
+

--- a/db/migrate/20251210000001_create_domain_throttles.rb
+++ b/db/migrate/20251210000001_create_domain_throttles.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class CreateDomainThrottles < ActiveRecord::Migration[7.0]
-
+class CreateDomainThrottles < ActiveRecord::Migration[7.1]
   def change
     create_table :domain_throttles, id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci" do |t|
       t.integer :server_id, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_10_000001) do
+ActiveRecord::Schema[7.1].define(version: 20251210000001) do
   create_table "additional_route_endpoints", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "route_id"
     t.string "endpoint_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_09_101656) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_10_000001) do
   create_table "additional_route_endpoints", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "route_id"
     t.string "endpoint_type"
@@ -72,6 +72,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_09_101656) do
     t.datetime "updated_at"
     t.boolean "hold", default: false
     t.string "uuid"
+  end
+
+  create_table "domain_throttles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "server_id", null: false
+    t.string "domain", null: false
+    t.datetime "throttled_until", null: false
+    t.string "reason"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.index ["server_id", "domain"], name: "index_domain_throttles_on_server_id_and_domain", unique: true
+    t.index ["throttled_until"], name: "index_domain_throttles_on_throttled_until"
   end
 
   create_table "domains", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|

--- a/doc/DOMAIN_THROTTLING.md
+++ b/doc/DOMAIN_THROTTLING.md
@@ -259,6 +259,63 @@ DomainThrottle.group(:domain)
 | `app/senders/smtp_sender.rb` | Rilevamento errori 451 |
 | `app/lib/message_dequeuer/outgoing_message_processor.rb` | Logica di throttling |
 | `app/scheduled_tasks/prune_domain_throttles_scheduled_task.rb` | Pulizia periodica |
+| `app/controllers/messages_controller.rb` | Actions per UI (`throttled_domains`, `remove_throttled_domain`) |
+| `app/views/messages/throttled_domains.html.haml` | Vista lista domini in throttle |
+| `app/views/messages/_header.html.haml` | Link nel menu di navigazione |
+| `config/routes.rb` | Routes per le nuove pagine |
+
+## Interfaccia Web
+
+### Accesso
+
+La pagina "Throttled Domains" è accessibile dalla sezione **Messages** di ogni server:
+
+```
+Organization → Server → Messages → Throttled Domains
+```
+
+### Funzionalità
+
+La pagina mostra una tabella con:
+
+| Colonna | Descrizione |
+|---------|-------------|
+| **Domain** | Il dominio destinatario in throttle |
+| **Throttled Until** | Data e ora di scadenza del throttle |
+| **Time Remaining** | Tempo rimanente in formato leggibile (es. "4m 30s") |
+| **Reason** | Il messaggio di errore originale del server SMTP |
+| **Actions** | Pulsante per rimuovere manualmente il throttle |
+
+### Rimozione Manuale
+
+È possibile rimuovere un throttle manualmente cliccando il pulsante "Remove". Questo è utile quando:
+
+- Il problema sul server remoto è stato risolto
+- Si vuole forzare un nuovo tentativo di invio
+- Il throttle è stato applicato erroneamente
+
+**Attenzione:** Rimuovere un throttle farà sì che i messaggi in coda vengano inviati immediatamente. Se il server remoto sta ancora limitando il rate, potrebbe risultare in ulteriori errori 451.
+
+### Screenshot Concettuale
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Messages │ Outgoing │ Incoming │ Queue │ Held │ Send │ Suppressions │ [Throttled] │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  Throttled Domains                                                          │
+│                                                                             │
+│  These domains are currently throttled due to rate limiting responses...   │
+│                                                                             │
+│  ┌────────────┬─────────────────────┬───────────┬──────────────┬─────────┐ │
+│  │ Domain     │ Throttled Until     │ Remaining │ Reason       │ Actions │ │
+│  ├────────────┼─────────────────────┼───────────┼──────────────┼─────────┤ │
+│  │ gmail.com  │ Dec 10, 2025 14:30  │ 4m 30s    │ 451 too many │ Remove  │ │
+│  │ yahoo.com  │ Dec 10, 2025 14:45  │ 19m 15s   │ Rate limit...│ Remove  │ │
+│  └────────────┴─────────────────────┴───────────┴──────────────┴─────────┘ │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
 
 ## Test
 

--- a/doc/DOMAIN_THROTTLING.md
+++ b/doc/DOMAIN_THROTTLING.md
@@ -1,0 +1,288 @@
+# Domain Throttling - Gestione Rate Limiting SMTP
+
+## Panoramica
+
+Il sistema di Domain Throttling gestisce automaticamente il rate limiting quando un server SMTP destinatario risponde con un errore 451 "too many messages, slow down". Invece di ritentare immediatamente l'invio (causando potenzialmente ulteriori rifiuti e danni alla reputazione IP), il sistema rallenta intelligentemente l'invio per tutti i messaggi destinati allo stesso dominio.
+
+## Problema Risolto
+
+Quando si invia un grande volume di email a un singolo dominio, il server destinatario può rispondere con:
+
+```
+451 4.7.1 Too many messages, slow down
+451 Rate limit exceeded, try again in 5 minutes
+451 Too many connections from your IP
+```
+
+Senza gestione del throttling:
+- ❌ Ogni messaggio viene ritentato individualmente
+- ❌ I retry multipli peggiorano la situazione
+- ❌ Rischio di blacklisting dell'IP
+- ❌ Spreco di risorse
+
+Con Domain Throttling:
+- ✅ Un solo messaggio riceve l'errore 451
+- ✅ Tutti i messaggi per lo stesso dominio vengono ritardati
+- ✅ La reputazione IP viene preservata
+- ✅ Efficienza delle risorse migliorata
+
+## Architettura
+
+### Componenti
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    OutgoingMessageProcessor                      │
+│  ┌─────────────────────┐    ┌──────────────────────────────┐   │
+│  │ skip_if_domain_     │    │ apply_domain_throttle_       │   │
+│  │ throttled           │    │ if_required                  │   │
+│  │ (prima dell'invio)  │    │ (dopo errore 451)            │   │
+│  └──────────┬──────────┘    └──────────────┬───────────────┘   │
+└─────────────┼───────────────────────────────┼───────────────────┘
+              │                               │
+              ▼                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      DomainThrottle Model                        │
+│  ┌─────────────┐  ┌────────────┐  ┌────────────────────────┐   │
+│  │ .throttled? │  │ .apply()   │  │ .cleanup_expired       │   │
+│  └─────────────┘  └────────────┘  └────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+              │                               │
+              ▼                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Database: domain_throttles                    │
+│  ┌──────────┬────────────┬─────────────────┬────────────────┐  │
+│  │server_id │ domain     │ throttled_until │ reason         │  │
+│  ├──────────┼────────────┼─────────────────┼────────────────┤  │
+│  │ 1        │ gmail.com  │ 2025-12-10 13:00│ 451 too many...│  │
+│  │ 1        │ yahoo.com  │ 2025-12-10 12:55│ Rate limit...  │  │
+│  └──────────┴────────────┴─────────────────┴────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Flusso di Esecuzione
+
+```
+1. Messaggio in coda
+        │
+        ▼
+2. Processor acquisisce lock
+        │
+        ▼
+3. Check: dominio in throttle? ──YES──► Imposta retry_after, rilascia lock
+        │
+        NO
+        ▼
+4. Procede con invio SMTP
+        │
+        ▼
+5. Risposta dal server destinatario
+        │
+   ┌────┴────┐
+   │         │
+ Successo   Errore 451
+   │         │
+   ▼         ▼
+6. Fine    Crea DomainThrottle
+           Aggiorna tutti i queued_messages 
+           per lo stesso dominio
+           Imposta retry_after
+```
+
+## Struttura Database
+
+### Tabella: domain_throttles
+
+| Campo | Tipo | Descrizione |
+|-------|------|-------------|
+| `id` | integer | Primary key |
+| `server_id` | integer | FK verso servers (throttle per-server) |
+| `domain` | string | Dominio destinatario (normalizzato lowercase) |
+| `throttled_until` | datetime | Timestamp fino a quando il dominio è in throttle |
+| `reason` | string | Messaggio di errore originale del server SMTP |
+| `created_at` | datetime | Timestamp creazione |
+| `updated_at` | datetime | Timestamp ultimo aggiornamento |
+
+**Indici:**
+- `UNIQUE (server_id, domain)` - Un solo throttle per dominio per server
+- `INDEX (throttled_until)` - Per query di pulizia efficienti
+
+## Configurazione
+
+### Costanti (DomainThrottle)
+
+```ruby
+# Durata default del throttle (5 minuti)
+DEFAULT_THROTTLE_DURATION = 300
+
+# Durata massima del throttle (30 minuti)
+MAX_THROTTLE_DURATION = 1800
+```
+
+### Pattern di Rilevamento
+
+Il sistema rileva automaticamente i seguenti pattern negli errori SMTP:
+
+- `451 ... too many` / `too many messages` / `too many connections`
+- `rate limit` / `rate limited`
+- `slow down`
+- `temporarily deferred` / `temporarily rejected` con menzione di rate/limit
+
+### Estrazione Durata
+
+Se il messaggio di errore contiene un tempo specifico, viene estratto:
+
+```
+"Try again in 30 seconds" → 40 secondi (30 + 10 buffer)
+"Retry in 5 minutes" → 310 secondi (5*60 + 10 buffer)
+"Try again in 2 hours" → 1800 secondi (capped a MAX)
+```
+
+## API del Modello DomainThrottle
+
+### Metodi di Classe
+
+```ruby
+# Verifica se un dominio è in throttle
+DomainThrottle.throttled?(server, "gmail.com")
+# => DomainThrottle instance o nil
+
+# Applica/estende un throttle
+DomainThrottle.apply(
+  server, 
+  "gmail.com",
+  duration: 300,           # opzionale, default 300
+  reason: "451 too many"   # opzionale
+)
+# => DomainThrottle instance
+
+# Pulisce i throttle scaduti
+DomainThrottle.cleanup_expired
+# => numero di record eliminati
+```
+
+### Scopes
+
+```ruby
+# Throttle attivi
+DomainThrottle.active
+
+# Throttle scaduti
+DomainThrottle.expired
+```
+
+### Metodi di Istanza
+
+```ruby
+throttle.active?           # => true/false
+throttle.remaining_seconds # => Integer (secondi rimanenti)
+```
+
+## Scheduled Task
+
+Il task `PruneDomainThrottlesScheduledTask` viene eseguito ogni **15 minuti** per rimuovere i record di throttle scaduti dal database.
+
+## Granularità
+
+Il throttling è applicato **per-server**, il che significa che:
+
+- Se il Server A riceve un 451 da `gmail.com`, solo i messaggi del Server A verso `gmail.com` vengono ritardati
+- Il Server B può continuare a inviare a `gmail.com` normalmente
+- Questo evita che un server sovraccarico impatti altri server nell'installazione
+
+## Comportamento Batch
+
+Quando viene rilevato un errore 451:
+
+1. Viene creato/aggiornato il `DomainThrottle` per il dominio
+2. **Tutti** i `queued_messages` dello stesso server con lo stesso dominio vengono aggiornati in batch con `retry_after`
+3. Questo previene che altri worker tentino di inviare mentre il dominio è in throttle
+
+```ruby
+# Query di aggiornamento batch
+QueuedMessage.where(server_id: server_id, domain: domain)
+             .where("retry_after IS NULL OR retry_after < ?", throttled_until)
+             .update_all(retry_after: throttled_until + 10.seconds)
+```
+
+## Backoff Esponenziale
+
+Se un dominio riceve ripetuti errori 451, la durata del throttle aumenta progressivamente:
+
+1. Primo 451: 5 minuti
+2. Secondo 451 (mentre ancora in throttle): tempo rimanente × 2 (max 30 minuti)
+
+Questo aiuta a gestire situazioni in cui il server destinatario ha bisogno di più tempo per recuperare.
+
+## Esempi di Utilizzo
+
+### Verifica Manuale dello Stato
+
+```ruby
+# In Rails console
+server = Server.find(1)
+
+# Verifica throttle attivi
+server.domain_throttles.active
+
+# Verifica se un dominio specifico è in throttle
+DomainThrottle.throttled?(server, "gmail.com")
+
+# Rimuovi manualmente un throttle
+DomainThrottle.find_by(server: server, domain: "gmail.com")&.destroy
+```
+
+### Monitoraggio
+
+```ruby
+# Conteggio throttle attivi per server
+Server.all.each do |s|
+  count = s.domain_throttles.active.count
+  puts "#{s.name}: #{count} domini in throttle" if count > 0
+end
+
+# Domini più frequentemente in throttle
+DomainThrottle.group(:domain)
+              .order('count_id DESC')
+              .count(:id)
+              .first(10)
+```
+
+## File Implementati
+
+| File | Descrizione |
+|------|-------------|
+| `db/migrate/20251210000001_create_domain_throttles.rb` | Migration database |
+| `app/models/domain_throttle.rb` | Modello ActiveRecord |
+| `app/models/server.rb` | Aggiunta associazione `has_many :domain_throttles` |
+| `app/senders/send_result.rb` | Nuovi attributi throttle |
+| `app/senders/smtp_sender.rb` | Rilevamento errori 451 |
+| `app/lib/message_dequeuer/outgoing_message_processor.rb` | Logica di throttling |
+| `app/scheduled_tasks/prune_domain_throttles_scheduled_task.rb` | Pulizia periodica |
+
+## Test
+
+I test sono disponibili in:
+
+- `spec/models/domain_throttle_spec.rb` - Test del modello
+- `spec/scheduled_tasks/prune_domain_throttles_scheduled_task_spec.rb` - Test scheduled task
+- `spec/senders/smtp_sender_spec.rb` - Test rilevamento throttle
+
+Eseguire i test:
+
+```bash
+bundle exec rspec spec/models/domain_throttle_spec.rb \
+                  spec/scheduled_tasks/prune_domain_throttles_scheduled_task_spec.rb \
+                  spec/senders/smtp_sender_spec.rb
+```
+
+## Migrazione
+
+Per attivare la funzionalità:
+
+```bash
+bundle exec rails db:migrate
+```
+
+La funzionalità è attiva immediatamente dopo la migrazione, senza necessità di configurazione aggiuntiva.
+

--- a/spec/factories/domain_throttle_factory.rb
+++ b/spec/factories/domain_throttle_factory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :domain_throttle do
+    association :server
+    sequence(:domain) { |n| "throttled-domain-#{n}.com" }
+    throttled_until { 5.minutes.from_now }
+    reason { "451 Too many messages, slow down" }
+  end
+end
+

--- a/spec/lib/database_schema_integrity_spec.rb
+++ b/spec/lib/database_schema_integrity_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Database Schema Integrity" do
+  describe "schema version" do
+    it "matches the latest migration timestamp" do
+      # Ottieni tutte le migration dalla directory
+      migration_files = Dir.glob(Rails.root.join("db", "migrate", "*.rb"))
+
+      # Estrai i timestamp dalle migration
+      migration_versions = migration_files.map do |file|
+        File.basename(file).split("_").first.to_i
+      end
+
+      # Trova la versione più recente
+      latest_migration_version = migration_versions.max
+
+      # Ottieni la versione corrente dello schema
+      schema_version = ActiveRecord::Base.connection.migration_context.current_version
+
+      # Verifica che corrispondano
+      expect(schema_version).to eq(latest_migration_version),
+                                   "Schema version (#{schema_version}) should match the latest migration (#{latest_migration_version})"
+    end
+  end
+
+  describe "schema file" do
+    it "contains the correct version number" do
+      schema_content = File.read(Rails.root.join("db", "schema.rb"))
+
+      # Estrai la versione dal file schema.rb
+      schema_version_match = schema_content.match(/ActiveRecord::Schema\[[\d.]+\]\.define\(version: (\d+)\)/)
+      expect(schema_version_match).not_to be_nil, "Could not find schema version in db/schema.rb"
+
+      schema_file_version = schema_version_match[1].to_i
+
+      # Ottieni l'ultima migration
+      migration_files = Dir.glob(Rails.root.join("db", "migrate", "*.rb"))
+      migration_versions = migration_files.map { |file| File.basename(file).split("_").first.to_i }
+      latest_migration_version = migration_versions.max
+
+      # Verifica che corrispondano
+      expect(schema_file_version).to eq(latest_migration_version),
+                                        "Schema file version (#{schema_file_version}) should match the latest migration (#{latest_migration_version})"
+    end
+  end
+
+  describe "DMARC fields migration" do
+    it "adds dmarc_status and dmarc_error columns to domains table" do
+      expect(Domain.column_names).to include("dmarc_status")
+      expect(Domain.column_names).to include("dmarc_error")
+    end
+  end
+
+  describe "Truemail integration migration" do
+    it "adds truemail_enabled column to servers table" do
+      expect(Server.column_names).to include("truemail_enabled")
+    end
+
+    it "has correct default value for truemail_enabled" do
+      column = Server.columns_hash["truemail_enabled"]
+      expect(column.default).to eq("0"), "truemail_enabled should default to false (0)"
+    end
+  end
+
+  describe "MTA-STS and TLS-RPT migration" do
+    it "adds MTA-STS fields to domains table" do
+      expect(Domain.column_names).to include("mta_sts_enabled")
+      expect(Domain.column_names).to include("mta_sts_mode")
+      expect(Domain.column_names).to include("mta_sts_max_age")
+      expect(Domain.column_names).to include("mta_sts_mx_patterns")
+      expect(Domain.column_names).to include("mta_sts_status")
+      expect(Domain.column_names).to include("mta_sts_error")
+    end
+
+    it "adds TLS-RPT fields to domains table" do
+      expect(Domain.column_names).to include("tls_rpt_enabled")
+      expect(Domain.column_names).to include("tls_rpt_email")
+      expect(Domain.column_names).to include("tls_rpt_status")
+      expect(Domain.column_names).to include("tls_rpt_error")
+    end
+  end
+
+  describe "Server priority migration" do
+    it "adds priority column to servers table" do
+      expect(Server.column_names).to include("priority")
+    end
+  end
+
+  describe "all migrations" do
+    it "have been applied to the database" do
+      # Ottieni tutte le migration dalla directory
+      migration_files = Dir.glob(Rails.root.join("db", "migrate", "*.rb"))
+      migration_versions = migration_files.map { |file| File.basename(file).split("_").first }
+
+      # Ottieni le migration applicate dal database
+      applied_migrations = ActiveRecord::Base.connection.migration_context.get_all_versions
+
+      # Verifica che tutte le migration siano state applicate
+      missing_migrations = migration_versions.map(&:to_i) - applied_migrations.map(&:to_i)
+
+      expect(missing_migrations).to be_empty,
+                                      "The following migrations have not been applied: #{missing_migrations.join(', ')}"
+    end
+  end
+end
+

--- a/spec/models/domain_throttle_spec.rb
+++ b/spec/models/domain_throttle_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DomainThrottle do
+  let(:organization) { create(:organization) }
+  let(:server) { create(:server, organization: organization) }
+
+  describe "validations" do
+    it "requires a domain" do
+      throttle = DomainThrottle.new(server: server, throttled_until: 1.hour.from_now)
+      expect(throttle).not_to be_valid
+      expect(throttle.errors[:domain]).to include("can't be blank")
+    end
+
+    it "requires a throttled_until" do
+      throttle = DomainThrottle.new(server: server, domain: "example.com")
+      expect(throttle).not_to be_valid
+      expect(throttle.errors[:throttled_until]).to include("can't be blank")
+    end
+
+    it "enforces uniqueness of domain per server" do
+      DomainThrottle.create!(server: server, domain: "example.com", throttled_until: 1.hour.from_now)
+      duplicate = DomainThrottle.new(server: server, domain: "example.com", throttled_until: 2.hours.from_now)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:domain]).to include("has already been taken")
+    end
+
+    it "allows same domain for different servers" do
+      other_server = create(:server, organization: organization, name: "other-server-#{SecureRandom.hex(4)}")
+      DomainThrottle.create!(server: server, domain: "example.com", throttled_until: 1.hour.from_now)
+      other_throttle = DomainThrottle.new(server: other_server, domain: "example.com", throttled_until: 2.hours.from_now)
+      expect(other_throttle).to be_valid
+    end
+  end
+
+  describe ".throttled?" do
+    it "returns nil when domain is not throttled" do
+      expect(DomainThrottle.throttled?(server, "example.com")).to be_nil
+    end
+
+    it "returns nil when throttle has expired" do
+      DomainThrottle.create!(server: server, domain: "example.com", throttled_until: 1.hour.ago)
+      expect(DomainThrottle.throttled?(server, "example.com")).to be_nil
+    end
+
+    it "returns the throttle when domain is actively throttled" do
+      throttle = DomainThrottle.create!(server: server, domain: "example.com", throttled_until: 1.hour.from_now)
+      expect(DomainThrottle.throttled?(server, "example.com")).to eq(throttle)
+    end
+
+    it "normalizes domain to lowercase" do
+      throttle = DomainThrottle.create!(server: server, domain: "example.com", throttled_until: 1.hour.from_now)
+      expect(DomainThrottle.throttled?(server, "EXAMPLE.COM")).to eq(throttle)
+    end
+  end
+
+  describe ".apply" do
+    it "creates a new throttle for a domain" do
+      expect {
+        DomainThrottle.apply(server, "example.com", duration: 300, reason: "451 too many messages")
+      }.to change(DomainThrottle, :count).by(1)
+
+      throttle = DomainThrottle.last
+      expect(throttle.domain).to eq("example.com")
+      expect(throttle.reason).to eq("451 too many messages")
+      expect(throttle.throttled_until).to be_within(5.seconds).of(Time.current + 300.seconds)
+    end
+
+    it "normalizes domain to lowercase" do
+      DomainThrottle.apply(server, "EXAMPLE.COM", duration: 300)
+      expect(DomainThrottle.last.domain).to eq("example.com")
+    end
+
+    it "updates existing throttle with longer duration" do
+      existing = DomainThrottle.create!(
+        server: server,
+        domain: "example.com",
+        throttled_until: 2.minutes.from_now,
+        reason: "original reason"
+      )
+
+      DomainThrottle.apply(server, "example.com", duration: 600, reason: "new reason")
+
+      existing.reload
+      expect(existing.reason).to eq("new reason")
+      expect(existing.throttled_until).to be_within(5.seconds).of(Time.current + 600.seconds)
+    end
+
+    it "uses default duration when not specified" do
+      DomainThrottle.apply(server, "example.com")
+      throttle = DomainThrottle.last
+      expect(throttle.throttled_until).to be_within(5.seconds).of(
+        Time.current + DomainThrottle::DEFAULT_THROTTLE_DURATION.seconds
+      )
+    end
+
+    it "truncates long reason strings" do
+      long_reason = "x" * 500
+      DomainThrottle.apply(server, "example.com", reason: long_reason)
+      expect(DomainThrottle.last.reason.length).to eq(255)
+    end
+  end
+
+  describe ".cleanup_expired" do
+    it "removes expired throttles" do
+      expired1 = DomainThrottle.create!(server: server, domain: "expired1.com", throttled_until: 2.hours.ago)
+      expired2 = DomainThrottle.create!(server: server, domain: "expired2.com", throttled_until: 1.minute.ago)
+      active = DomainThrottle.create!(server: server, domain: "active.com", throttled_until: 1.hour.from_now)
+
+      deleted_count = DomainThrottle.cleanup_expired
+
+      expect(deleted_count).to eq(2)
+      expect(DomainThrottle.exists?(expired1.id)).to be false
+      expect(DomainThrottle.exists?(expired2.id)).to be false
+      expect(DomainThrottle.exists?(active.id)).to be true
+    end
+
+    it "returns 0 when no expired throttles exist" do
+      DomainThrottle.create!(server: server, domain: "active.com", throttled_until: 1.hour.from_now)
+      expect(DomainThrottle.cleanup_expired).to eq(0)
+    end
+  end
+
+  describe "#remaining_seconds" do
+    it "returns the remaining seconds for an active throttle" do
+      throttle = DomainThrottle.new(throttled_until: 5.minutes.from_now)
+      expect(throttle.remaining_seconds).to be_within(5).of(300)
+    end
+
+    it "returns 0 for an expired throttle" do
+      throttle = DomainThrottle.new(throttled_until: 1.minute.ago)
+      expect(throttle.remaining_seconds).to eq(0)
+    end
+  end
+
+  describe "#active?" do
+    it "returns true when throttle is still active" do
+      throttle = DomainThrottle.new(throttled_until: 1.hour.from_now)
+      expect(throttle.active?).to be true
+    end
+
+    it "returns false when throttle has expired" do
+      throttle = DomainThrottle.new(throttled_until: 1.minute.ago)
+      expect(throttle.active?).to be false
+    end
+  end
+
+  describe "scopes" do
+    before do
+      @active1 = DomainThrottle.create!(server: server, domain: "active1.com", throttled_until: 1.hour.from_now)
+      @active2 = DomainThrottle.create!(server: server, domain: "active2.com", throttled_until: 30.minutes.from_now)
+      @expired1 = DomainThrottle.create!(server: server, domain: "expired1.com", throttled_until: 1.hour.ago)
+      @expired2 = DomainThrottle.create!(server: server, domain: "expired2.com", throttled_until: 1.minute.ago)
+    end
+
+    describe ".active" do
+      it "returns only active throttles" do
+        expect(DomainThrottle.active).to contain_exactly(@active1, @active2)
+      end
+    end
+
+    describe ".expired" do
+      it "returns only expired throttles" do
+        expect(DomainThrottle.expired).to contain_exactly(@expired1, @expired2)
+      end
+    end
+  end
+end
+

--- a/spec/scheduled_tasks/prune_domain_throttles_scheduled_task_spec.rb
+++ b/spec/scheduled_tasks/prune_domain_throttles_scheduled_task_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PruneDomainThrottlesScheduledTask do
+  let(:organization) { create(:organization) }
+  let(:server) { create(:server, organization: organization) }
+  let(:logger) { instance_double("Logger", info: nil, debug: nil, error: nil) }
+  let(:task) { described_class.new(logger: logger) }
+
+  describe "#call" do
+    it "removes expired domain throttles" do
+      expired1 = DomainThrottle.create!(server: server, domain: "expired1.com", throttled_until: 2.hours.ago)
+      expired2 = DomainThrottle.create!(server: server, domain: "expired2.com", throttled_until: 1.minute.ago)
+      active = DomainThrottle.create!(server: server, domain: "active.com", throttled_until: 1.hour.from_now)
+
+      task.call
+
+      expect(DomainThrottle.exists?(expired1.id)).to be false
+      expect(DomainThrottle.exists?(expired2.id)).to be false
+      expect(DomainThrottle.exists?(active.id)).to be true
+    end
+
+    it "does not raise errors when no throttles exist" do
+      expect { task.call }.not_to raise_error
+    end
+  end
+
+  describe ".next_run_after" do
+    it "returns a time 15 minutes in the future" do
+      next_run = described_class.next_run_after
+      expect(next_run).to be_within(1.minute).of(15.minutes.from_now)
+    end
+  end
+end
+

--- a/spec/senders/smtp_sender_spec.rb
+++ b/spec/senders/smtp_sender_spec.rb
@@ -499,6 +499,109 @@ RSpec.describe SMTPSender do
           expect(sender.endpoints.last).to have_received(:reset_smtp_session)
         end
       end
+
+      context "when the SMTP server returns a 451 rate limit error" do
+        let(:smtp_send_message_error) { proc { Net::SMTPServerBusy.new("451 4.7.1 Too many messages, slow down") } }
+
+        it "returns a SoftFail with domain throttle required" do
+          result = sender.send_message(message)
+          expect(result).to be_a SendResult
+          expect(result).to have_attributes(
+            type: "SoftFail",
+            domain_throttle_required: true
+          )
+          expect(result.domain_throttle_duration).to be_a(Integer)
+          expect(result.domain_throttle_duration).to be >= DomainThrottle::DEFAULT_THROTTLE_DURATION
+        end
+      end
+
+      context "when the SMTP server returns a rate limit error with seconds" do
+        let(:smtp_send_message_error) { proc { Net::SMTPServerBusy.new("451 Too many messages, try again in 120 seconds") } }
+
+        it "extracts the throttle duration from the message" do
+          result = sender.send_message(message)
+          expect(result).to have_attributes(
+            domain_throttle_required: true,
+            domain_throttle_duration: 300  # max of (120 + 10) and DEFAULT_THROTTLE_DURATION (300)
+          )
+        end
+      end
+
+      context "when the SMTP server returns a rate limit error with minutes" do
+        let(:smtp_send_message_error) { proc { Net::SMTPServerBusy.new("451 Rate limit exceeded, retry in 10 minutes") } }
+
+        it "extracts the throttle duration from the message" do
+          result = sender.send_message(message)
+          expect(result).to have_attributes(
+            domain_throttle_required: true,
+            domain_throttle_duration: 610  # (10 * 60) + 10
+          )
+        end
+      end
+
+      context "when the SMTP server returns a non-rate-limit error" do
+        let(:smtp_send_message_error) { proc { Net::SMTPServerBusy.new("450 Mailbox temporarily unavailable") } }
+
+        it "does not require domain throttle" do
+          result = sender.send_message(message)
+          expect(result).to have_attributes(
+            type: "SoftFail",
+            domain_throttle_required: nil
+          )
+        end
+      end
+    end
+  end
+
+  describe "#requires_domain_throttle?" do
+    it "returns true for 451 too many messages" do
+      expect(sender.send(:requires_domain_throttle?, "451 4.7.1 Too many messages")).to be true
+    end
+
+    it "returns true for slow down messages" do
+      expect(sender.send(:requires_domain_throttle?, "451 slow down")).to be true
+    end
+
+    it "returns true for rate limit messages" do
+      expect(sender.send(:requires_domain_throttle?, "Rate limit exceeded, please try again later")).to be true
+    end
+
+    it "returns true for too many connections" do
+      expect(sender.send(:requires_domain_throttle?, "Too many connections from your IP")).to be true
+    end
+
+    it "returns false for generic errors" do
+      expect(sender.send(:requires_domain_throttle?, "450 Mailbox temporarily unavailable")).to be false
+    end
+
+    it "returns false for nil messages" do
+      expect(sender.send(:requires_domain_throttle?, nil)).to be false
+    end
+
+    it "returns false for empty messages" do
+      expect(sender.send(:requires_domain_throttle?, "")).to be false
+    end
+  end
+
+  describe "#extract_throttle_duration" do
+    it "extracts duration from seconds format" do
+      expect(sender.send(:extract_throttle_duration, "Try again in 60 seconds")).to eq(300) # min of 60+10 and 300
+    end
+
+    it "extracts duration from minutes format" do
+      expect(sender.send(:extract_throttle_duration, "Retry in 10 minutes")).to eq(610)
+    end
+
+    it "returns default duration for messages without time" do
+      expect(sender.send(:extract_throttle_duration, "Too many messages")).to eq(DomainThrottle::DEFAULT_THROTTLE_DURATION)
+    end
+
+    it "returns default duration for nil messages" do
+      expect(sender.send(:extract_throttle_duration, nil)).to eq(DomainThrottle::DEFAULT_THROTTLE_DURATION)
+    end
+
+    it "caps hours at MAX_THROTTLE_DURATION" do
+      expect(sender.send(:extract_throttle_duration, "Try again in 2 hours")).to eq(DomainThrottle::MAX_THROTTLE_DURATION)
     end
   end
 


### PR DESCRIPTION
This pull request introduces domain-level throttling to prevent sending emails to domains that are temporarily rejecting messages due to rate limiting (e.g., SMTP 451 errors). The implementation ensures that when a domain signals rate limiting, further messages to that domain are held and retried after a cooldown period. It also provides a UI for monitoring and managing throttled domains. 

The most important changes are:

**Domain Throttling Core Logic:**
- Added a new `DomainThrottle` model with logic to track, apply, and expire throttles per domain and server, including exponential backoff and cleanup methods. (`app/models/domain_throttle.rb`, `db/migrate/20251210000001_create_domain_throttles.rb`) [[1]](diffhunk://#diff-0a25184960d29c0595026a15891b9e2115a81b5ffbad6ad9be1143c9bf74aa83R1-R96) [[2]](diffhunk://#diff-0298b12b9cf27fa290596f2176b70191147d14a054494ca617466fc64e4bf806R1-R20)
- Updated the outgoing message processor to (a) skip sending if the recipient's domain is throttled and requeue the message, and (b) apply or extend a throttle when required, updating all queued messages for that domain. (`app/lib/message_dequeuer/outgoing_message_processor.rb`) [[1]](diffhunk://#diff-0e9f12afc35fb76deab13eb643a5355f028c2615379c139bcf274ccb680e0b81R13) [[2]](diffhunk://#diff-0e9f12afc35fb76deab13eb643a5355f028c2615379c139bcf274ccb680e0b81R22) [[3]](diffhunk://#diff-0e9f12afc35fb76deab13eb643a5355f028c2615379c139bcf274ccb680e0b81R81-R99) [[4]](diffhunk://#diff-0e9f12afc35fb76deab13eb643a5355f028c2615379c139bcf274ccb680e0b81R184-R228)
- Enhanced the SMTP sender to detect rate limiting responses, set throttle flags and durations on `SendResult`, and extract throttle durations from SMTP error messages. (`app/senders/smtp_sender.rb`, `app/senders/send_result.rb`) [[1]](diffhunk://#diff-9dd19459c1dfb3dd055613cb00f857ed8284f9d0e95c81a2dc5432566d0b00d8R110-R116) [[2]](diffhunk://#diff-9dd19459c1dfb3dd055613cb00f857ed8284f9d0e95c81a2dc5432566d0b00d8R246-R285) [[3]](diffhunk://#diff-44103770dc3634b23f2c616bd0cb6355f94dbbf74b107707becec519caa758e2R14-R15)

**User Interface & Management:**
- Added a new UI page and navigation for listing and managing throttled domains, including the ability to manually remove throttles. (`app/views/messages/throttled_domains.html.haml`, `app/views/messages/_header.html.haml`, `app/assets/stylesheets/application/components/_throttle_list.scss`, `app/controllers/messages_controller.rb`, `config/routes.rb`) [[1]](diffhunk://#diff-d400f7a612445ee339d83923b94933db2afd984235fcb685d377e8b58f256dfcR1-R42) [[2]](diffhunk://#diff-b457ef2b2434af85114b3adeb65ebb06b5f2fe9a3d353c62cf34386a3c5b1a26R9) [[3]](diffhunk://#diff-f01ba92dbb193b907b9657a5bb0c89ddf0fcaf5c5c1642bcce3d2d131e3504b5R1-R54) [[4]](diffhunk://#diff-9b58332ea76756301b1aafeacfb0659d1244ba014947602b0e0bf2d0f2921d26R150-R166) [[5]](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R54-R55)

**Maintenance:**
- Introduced a scheduled task to periodically prune expired throttles from the database. (`app/scheduled_tasks/prune_domain_throttles_scheduled_task.rb`)

**Model and Association Updates:**
- Added the `domain_throttles` association to the `Server` model for proper cascading deletes and access. (`app/models/server.rb`)