### PR TITLE
feat: reallocates ip address for the retry after a softfail

### DIFF
--- a/app/lib/message_dequeuer/outgoing_message_processor.rb
+++ b/app/lib/message_dequeuer/outgoing_message_processor.rb
@@ -258,6 +258,12 @@ module MessageDequeuer
 
     def finish_processing
       if @result.retry
+        # Reallocate IP address on SoftFail to try with a different IP on next attempt
+        if @result.type == "SoftFail"
+          queued_message.reallocate_ip_address
+          log "reallocated IP address for retry", new_ip_address_id: queued_message.ip_address_id
+        end
+
         queued_message.retry_later(@result.retry.is_a?(Integer) ? @result.retry : nil)
         log "message requeued for trying later", retry_after: queued_message.retry_after
         stop_processing

--- a/app/models/queued_message.rb
+++ b/app/models/queued_message.rb
@@ -59,6 +59,26 @@ class QueuedMessage < ApplicationRecord
     self.ip_address = pool.ip_addresses.select_by_priority
   end
 
+  # Reallocate a different IP address for retry attempts (e.g., after a SoftFail).
+  # Tries to select a different IP from the current one if possible.
+  def reallocate_ip_address
+    return unless Postal.ip_pools?
+    return if message.nil?
+
+    pool = server.ip_pool_for_message(message)
+    return if pool.nil?
+
+    available_ips = pool.ip_addresses.where.not(id: ip_address_id)
+    new_ip = if available_ips.exists?
+               available_ips.select_by_priority
+             else
+               # If there's only one IP in the pool, keep the same one
+               pool.ip_addresses.select_by_priority
+             end
+
+    update_column(:ip_address_id, new_ip.id) if new_ip
+  end
+
   def batchable_messages(limit = 10)
     unless locked?
       raise Postal::Error, "Must lock current message before locking any friends"

--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -250,6 +250,10 @@ class SMTPSender < BaseSender
   def requires_domain_throttle?(message)
     return false if message.blank?
 
+    # Exclude messages that contain an IP address (these are typically IP-specific blocks, not domain throttling)
+    ip_pattern = /\b(?:\d{1,3}\.){3}\d{1,3}\b/
+    return false if message.match?(ip_pattern)
+
     # Match common patterns for rate limiting responses
     # 451 is the standard code for "try again later"
     throttle_patterns = [

--- a/spec/lib/message_dequeuer/outgoing_message_processor_spec.rb
+++ b/spec/lib/message_dequeuer/outgoing_message_processor_spec.rb
@@ -567,6 +567,16 @@ module MessageDequeuer
             expect(queued_message.reload.retry_after).to eq retry_time
           end
         end
+
+        it "reallocates the IP address for the retry" do
+          expect(queued_message).to receive(:reallocate_ip_address)
+          processor.process
+        end
+
+        it "logs the IP reallocation" do
+          processor.process
+          expect(logger).to have_logged(/reallocated IP address for retry/)
+        end
       end
 
       context "if the message should not be retried" do

--- a/spec/models/queued_message_spec.rb
+++ b/spec/models/queued_message_spec.rb
@@ -169,6 +169,82 @@ RSpec.describe QueuedMessage do
     end
   end
 
+  describe "#reallocate_ip_address" do
+    subject(:queued_message) { create(:queued_message) }
+
+    context "when ip pools is disabled" do
+      it "returns nil" do
+        expect(queued_message.reallocate_ip_address).to be nil
+      end
+
+      it "does not change the IP address" do
+        original_ip_id = queued_message.ip_address_id
+        queued_message.reallocate_ip_address
+        expect(queued_message.reload.ip_address_id).to eq original_ip_id
+      end
+    end
+
+    context "when IP pools is enabled" do
+      before do
+        allow(Postal::Config.postal).to receive(:use_ip_pools?).and_return(true)
+      end
+
+      context "when there is no backend message" do
+        it "returns nil" do
+          expect(queued_message.reallocate_ip_address).to be nil
+        end
+      end
+
+      context "when no IP pool can be determined for the message" do
+        let(:server) { create(:server) }
+        let(:message) { MessageFactory.outgoing(server) }
+
+        subject(:queued_message) { create(:queued_message, message: message) }
+
+        it "returns nil" do
+          expect(queued_message.reallocate_ip_address).to be nil
+        end
+      end
+
+      context "when an IP pool has multiple IP addresses" do
+        let(:ip_pool) { create(:ip_pool) }
+        let!(:ip_address1) { create(:ip_address, ip_pool: ip_pool, ipv4: "10.0.0.1", ipv6: "2001:db8::1") }
+        let!(:ip_address2) { create(:ip_address, ip_pool: ip_pool, ipv4: "10.0.0.2", ipv6: "2001:db8::2") }
+        let(:server) { create(:server, ip_pool: ip_pool) }
+        let(:message) { MessageFactory.outgoing(server) }
+
+        subject(:queued_message) do
+          qm = create(:queued_message, message: message)
+          qm.update_column(:ip_address_id, ip_address1.id)
+          qm
+        end
+
+        it "allocates a different IP address" do
+          queued_message.reallocate_ip_address
+          expect(queued_message.reload.ip_address_id).to eq ip_address2.id
+        end
+
+        it "updates the ip_address_id in the database" do
+          expect { queued_message.reallocate_ip_address }.to change { queued_message.reload.ip_address_id }.from(ip_address1.id).to(ip_address2.id)
+        end
+      end
+
+      context "when an IP pool has only one IP address" do
+        let(:ip_pool) { create(:ip_pool, :with_ip_address) }
+        let(:server) { create(:server, ip_pool: ip_pool) }
+        let(:message) { MessageFactory.outgoing(server) }
+
+        subject(:queued_message) { create(:queued_message, message: message) }
+
+        it "keeps the same IP address when there are no alternatives" do
+          original_ip_id = queued_message.ip_address_id
+          queued_message.reallocate_ip_address
+          expect(queued_message.reload.ip_address_id).to eq original_ip_id
+        end
+      end
+    end
+  end
+
   describe "#batchable_messages" do
     context "when the message is not locked" do
       subject(:queued_message) { build(:queued_message) }

--- a/spec/senders/smtp_sender_spec.rb
+++ b/spec/senders/smtp_sender_spec.rb
@@ -581,6 +581,18 @@ RSpec.describe SMTPSender do
     it "returns false for empty messages" do
       expect(sender.send(:requires_domain_throttle?, "")).to be false
     end
+
+    it "returns false when message contains an IPv4 address" do
+      expect(sender.send(:requires_domain_throttle?, "451 Too many messages from 192.168.1.100")).to be false
+    end
+
+    it "returns false when message contains an IP address with rate limit text" do
+      expect(sender.send(:requires_domain_throttle?, "451 Rate limit exceeded for IP 10.0.0.1, slow down")).to be false
+    end
+
+    it "returns false for IP-specific blocks" do
+      expect(sender.send(:requires_domain_throttle?, "Connection rate limit exceeded for 203.0.113.50")).to be false
+    end
   end
 
   describe "#extract_throttle_duration" do


### PR DESCRIPTION
This pull request introduces improvements to how outgoing email retries are handled, particularly focusing on IP address reallocation after a soft failure and refining domain throttling detection. The main changes include adding logic to reallocate a different IP address for retry attempts, updating domain throttling checks to avoid false positives for IP-based blocks, and providing comprehensive test coverage for these updates.

**Retry logic and IP address management:**

* Added a new `reallocate_ip_address` method to `QueuedMessage` that attempts to assign a different IP address from the pool when retrying a message after a soft failure, falling back to the same IP if no alternatives exist.
* Updated `OutgoingMessageProcessor` to call `reallocate_ip_address` and log the event when retrying a message due to a soft failure.

**Domain throttling detection:**

* Enhanced the `requires_domain_throttle?` method in `SmtpSender` to exclude messages containing IP addresses, preventing misclassification of IP-specific blocks as domain throttling.

**Test coverage:**

* Added and expanded tests for `QueuedMessage#reallocate_ip_address` to cover various scenarios, including multiple IPs, single IP, and disabled IP pools.
* Updated `OutgoingMessageProcessor` specs to verify that IP reallocation and logging occur on soft failure retries.
* Added tests for `requires_domain_throttle?` to ensure correct handling of IP-based messages.