### PR TITLE
Replica: fix: add X-Envelope-From header

### DIFF
--- a/app/lib/smtp_server/client.rb
+++ b/app/lib/smtp_server/client.rb
@@ -419,6 +419,10 @@ module SMTPServer
       received_header = ReceivedHeader.generate(@credential&.server, @helo_name, @ip_address, :smtp)
                                       .force_encoding("BINARY")
 
+      envelope_header = "<#{@mail_from}>"
+      @data << "X-Envelope-From: #{envelope_header}\r\n"
+      @headers["x-envelope-from"] = [envelope_header]
+
       @data << "Received: #{received_header}\r\n"
       @headers["received"] = [received_header]
 

--- a/spec/lib/smtp_server/client/data_spec.rb
+++ b/spec/lib/smtp_server/client/data_spec.rb
@@ -75,6 +75,7 @@ module SMTPServer
             client.handle("This is some content for the message.")
             client.handle("It will keep going.")
             expect(client.instance_variable_get("@data")).to eq <<~DATA
+              X-Envelope-From: <test@test.com>\r
               Received: from test.example.com (1.2.3.4 [1.2.3.4]) by #{Postal::Config.postal.smtp_hostname} with SMTP; #{Time.now.utc.rfc2822}\r
               Subject: Test\r
               \r


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3512

**Autore originale:** @Mortza81
**Branch originale:** `fix/add-x-envelope-from-header`
**Repository originale:** Mortza81/postal

---

## Summary

This PR adds the `X-Envelope-From` header to incoming messages to preserve the SMTP
envelope sender (`MAIL FROM`) for SPF evaluation by SpamAssassin.

## Background

SpamAssassin relies on message headers to determine the envelope sender for SPF checks.
If no suitable header is present (e.g. `Return-Path` or `X-Envelope-From`), SPF evaluation
may be skipped and debug messages such as `cannot get Envelope-From` are logged.

## Motivation

Providing `X-Envelope-From` ensures the envelope sender is always available for SPF
evaluation, improving accuracy and consistency with SpamAssassin’s documented behavior.

## References

- https://spamassassin.apache.org/full/4.0.x/doc/Mail_SpamAssassin_Conf.html

## Impact

- No change to message delivery
- Improves SPF reliability for incoming mail only
