### PR TITLE
Replica: Add ARM64 Docker image support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
@@ -37,7 +38,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ci
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
   test:
     name: Test Suite
@@ -103,7 +104,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: full
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ steps.info.outputs.version }}
             BRANCH=${{ steps.info.outputs.branch }}
@@ -133,4 +134,4 @@ jobs:
           target: full
           build-args: |
             VERSION=${{ needs.release-please.outputs.version }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          tags: ghcr.io/${{ github.repository_owner }}/postal:ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ci
@@ -55,10 +55,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: docker compose pull
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          POSTAL_IMAGE: ghcr.io/${{ github.repository_owner }}/postal:ci-${{ github.sha }}
       - run: docker compose run postal sh -c 'bundle exec rspec'
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          POSTAL_IMAGE: ghcr.io/${{ github.repository_owner }}/postal:ci-${{ github.sha }}
 
   release-branch:
     name: Release (branch)
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: info
         run: |
-          IMAGE=ghcr.io/postalserver/postal
+          IMAGE=ghcr.io/${{ github.repository_owner }}/postal
 
           REF="${GITHUB_REF#refs/heads/}"
           if [ -z "$REF" ]; then exit 1; fi
@@ -127,8 +127,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/postalserver/postal:stable
-            ghcr.io/postalserver/postal:${{ needs.release-please.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/postal:stable
+            ghcr.io/${{ github.repository_owner }}/postal:${{ needs.release-please.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: full


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3516

**Autore originale:** @aalonzolu
**Branch originale:** `feature/arm64support`
**Repository originale:** aalonzolu/postal

---

Adds ARM64 architecture support to Docker images, enabling Postal to run on ARM devices including Apple Silicon Macs, ARM servers, and Raspberry Pi.

**Changes:**
- Added QEMU emulation to CI workflow  
- Updated all build jobs to support `linux/amd64,linux/arm64` platforms
- Creates unified multi-architecture manifests for existing image tags

**Benefits:**
- ✅ Zero breaking changes for AMD64 users
- ✅ Same image tags work on both architectures  
- ✅ Enables deployment on modern ARM hardware
- ✅ Follows existing build strategy and processes

**Testing:** Multi-architecture builds completed successfully with both AMD64 and ARM64 images compiling without errors.