### PR TITLE
Add SMTP authentication failure blocking system with admin dashboard

### DIFF
--- a/app/controllers/admin_blocked_ips_controller.rb
+++ b/app/controllers/admin_blocked_ips_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class AdminBlockedIpsController < ApplicationController
+
+  before_action :admin_required
+
+  def index
+    # Get search query
+    @query = params[:query]
+
+    # Cleanup expired entries periodically
+    SMTPServer::AuthFailureTracker.cleanup_blocked_index if should_cleanup?
+
+    # Get blocked IPs (with search if query present)
+    if @query.present?
+      @blocked_ips = SMTPServer::AuthFailureTracker.search_blocked(@query)
+    else
+      @blocked_ips = SMTPServer::AuthFailureTracker.all_blocked
+    end
+
+    # Pagination
+    @page = (params[:page] || 1).to_i
+    @per_page = 50
+    @total_blocked = @blocked_ips.size
+    @blocked_ips = @blocked_ips.drop((@page - 1) * @per_page).take(@per_page)
+    @total_pages = (@total_blocked.to_f / @per_page).ceil
+  end
+
+  def unblock
+    ip_address = params[:ip]
+
+    if ip_address.blank?
+      flash[:error] = "IP address is required"
+      redirect_to admin_blocked_ips_path
+      return
+    end
+
+    if SMTPServer::AuthFailureTracker.unblock(ip_address)
+      flash[:notice] = "IP address #{ip_address} has been unblocked successfully"
+    else
+      flash[:error] = "Failed to unblock IP address #{ip_address}"
+    end
+
+    redirect_to admin_blocked_ips_path
+  end
+
+  def unblock_all
+    blocked_ips = SMTPServer::AuthFailureTracker.all_blocked
+    count = 0
+
+    blocked_ips.each do |ip_info|
+      if SMTPServer::AuthFailureTracker.unblock(ip_info[:ip_address])
+        count += 1
+      end
+    end
+
+    flash[:notice] = "Successfully unblocked #{count} IP address#{count == 1 ? '' : 'es'}"
+    redirect_to admin_blocked_ips_path
+  end
+
+  def cleanup
+    cleaned = SMTPServer::AuthFailureTracker.cleanup_blocked_index
+    flash[:notice] = "Cleaned up #{cleaned} expired entr#{cleaned == 1 ? 'y' : 'ies'}"
+    redirect_to admin_blocked_ips_path
+  end
+
+  private
+
+  # Cleanup expired entries every 10th request to avoid overhead
+  def should_cleanup?
+    rand(10).zero?
+  end
+
+end

--- a/app/lib/smtp_server/README_AUTH_BLOCKING.md
+++ b/app/lib/smtp_server/README_AUTH_BLOCKING.md
@@ -1,0 +1,439 @@
+# SMTP Authentication Failure Blocking System
+
+## Overview
+
+This system protects the SMTP server against brute force authentication attacks by automatically blocking IP addresses that exceed a configurable number of failed authentication attempts.
+
+## Features
+
+- ✅ Automatic IP blocking after X failed authentication attempts
+- ✅ Configurable threshold (default: 5 attempts)
+- ✅ Configurable block duration (default: 120 minutes)
+- ✅ Automatic failure counter reset on successful authentication
+- ✅ Tracks failures across all authentication methods (PLAIN, LOGIN, CRAM-MD5)
+- ✅ Per-IP tracking with independent counters
+- ✅ Uses Rails.cache for fast, distributed storage
+- ✅ Prometheus metrics for monitoring
+- ✅ Detailed security logging
+- ✅ Comprehensive test coverage
+
+## Quick Start
+
+### Configuration
+
+Add to your `postal.yml`:
+
+```yaml
+version: 2
+
+smtp_server:
+  auth_failure_threshold: 5      # Block after 5 failures
+  auth_failure_block_duration: 120  # Block for 120 minutes (2 hours)
+```
+
+Or use environment variables:
+
+```bash
+SMTP_SERVER__AUTH_FAILURE_THRESHOLD=5
+SMTP_SERVER__AUTH_FAILURE_BLOCK_DURATION=120
+```
+
+### Monitoring
+
+Check Prometheus metrics:
+
+```
+# Number of IPs blocked
+postal_smtp_server_auth_blocks_total
+
+# Number of blocked attempts
+postal_smtp_server_client_errors{error="ip-blocked"}
+
+# Failed authentication attempts
+postal_smtp_server_client_errors{error="invalid-credentials"}
+```
+
+### Manual Unblocking
+
+If you need to manually unblock an IP:
+
+```ruby
+# In Rails console
+SMTPServer::AuthFailureTracker.unblock("192.168.1.100")
+```
+
+## How It Works
+
+### 1. Failure Tracking
+
+When a client fails to authenticate:
+
+1. The IP address is extracted from the connection
+2. A failure counter is incremented in Rails.cache
+3. The counter has an automatic expiry (15-minute window)
+4. If the threshold is reached, the IP is blocked
+
+### 2. Blocking
+
+When an IP exceeds the threshold:
+
+1. A block record is created in Rails.cache
+2. The block includes metadata (timestamp, failure count)
+3. The block expires after the configured duration
+4. All new authentication attempts from that IP are rejected
+
+### 3. Success Reset
+
+When authentication succeeds:
+
+1. The failure counter is immediately reset to 0
+2. This allows legitimate users to occasionally mistype passwords
+3. The user can continue without being blocked
+
+## Architecture
+
+### Files
+
+```
+app/lib/smtp_server/
+├── auth_failure_tracker.rb      # Core tracking logic
+└── client.rb                     # Integration with SMTP client
+
+lib/postal/
+└── config_schema.rb              # Configuration schema
+
+spec/lib/smtp_server/
+├── auth_failure_tracker_spec.rb       # Unit tests
+└── client/auth_blocking_spec.rb       # Integration tests
+
+doc/
+└── SMTP_AUTH_BLOCKING.md         # User documentation
+```
+
+### Key Classes
+
+#### `SMTPServer::AuthFailureTracker`
+
+Core tracking class that manages failure counters and blocks.
+
+**Key Methods:**
+
+- `blocked?` - Check if IP is currently blocked
+- `record_failure_and_check_threshold` - Record failure and check if should block
+- `record_success` - Reset counter on successful auth
+- `block_ip` - Manually block an IP
+- `unblock_ip` - Manually unblock an IP
+
+**Class Methods:**
+
+- `AuthFailureTracker.blocked?(ip)` - Check if IP is blocked
+- `AuthFailureTracker.record_and_check(ip:, ...)` - Record and check
+- `AuthFailureTracker.unblock(ip)` - Unblock an IP
+
+#### `SMTPServer::Client`
+
+SMTP client handler, modified to integrate blocking.
+
+**Integration Points:**
+
+- `initialize` - No longer pre-creates tracker (lazy load)
+- `auth_failure_tracker` - Lazy-loading accessor for tracker
+- `auth_plain`, `auth_login`, `auth_cram_md5` - Check if IP is blocked
+- `authenticate` - Track failures and successes
+
+### Cache Keys
+
+The system uses SHA-256 hashed cache keys:
+
+```
+Failure counter: smtp_auth:failures:v1:<sha256_of_ip>
+Block status:    smtp_auth:blocked:v1:<sha256_of_ip>
+```
+
+Hashing provides:
+- Security against cache key manipulation
+- Normalized key length regardless of IP format
+- Version prefix allows future schema changes
+
+### State Machine
+
+```
+┌─────────────┐
+│   Normal    │  ← Successful auth resets counter
+│ (unblocked) │
+└──────┬──────┘
+       │
+       │ Failed auth attempt
+       │
+       ▼
+┌─────────────┐
+│  Tracking   │  ← Counter increments, not blocked yet
+│  Failures   │     (counter < threshold)
+└──────┬──────┘
+       │
+       │ Failure count >= threshold
+       │
+       ▼
+┌─────────────┐
+│   Blocked   │  ← All auth attempts rejected
+│             │     421 response returned
+└──────┬──────┘
+       │
+       │ Block expires (after configured duration)
+       │
+       ▼
+┌─────────────┐
+│   Normal    │  ← Counter cleared, can retry
+└─────────────┘
+```
+
+## Testing
+
+### Unit Tests
+
+```bash
+bundle exec rspec spec/lib/smtp_server/auth_failure_tracker_spec.rb
+```
+
+Tests the `AuthFailureTracker` class in isolation:
+- Blocking/unblocking
+- Counter management
+- Configuration integration
+- Cache key security
+
+### Integration Tests
+
+```bash
+bundle exec rspec spec/lib/smtp_server/client/auth_blocking_spec.rb
+```
+
+Tests the full system integrated with SMTP client:
+- AUTH PLAIN, LOGIN, CRAM-MD5 blocking
+- Successful auth reset
+- Cross-method failure tracking
+- Independent IP tracking
+- Logging and metrics
+
+### Run All Tests
+
+```bash
+bundle exec rspec spec/lib/smtp_server/
+```
+
+## Security Considerations
+
+### Cache Backend
+
+- Uses Rails.cache for storage (memory, Redis, Memcached, etc.)
+- Must be shared across SMTP servers in distributed deployments
+- Configure appropriate memory limits
+- Consider persistence across restarts
+
+### Hashed Cache Keys
+
+- IP addresses are SHA-256 hashed before use as cache keys
+- Prevents cache key manipulation attacks
+- Normalizes IPv4/IPv6 differences
+
+### Rate vs. Blocking
+
+This is a **blocking** system, not rate limiting:
+
+| Feature | Blocking (This System) | Rate Limiting |
+|---------|------------------------|---------------|
+| Purpose | Stop brute force | Control request rate |
+| Action | Binary (block/allow) | Throttle/delay |
+| Recovery | Time-based expiry | Continuous |
+| Best for | Security | Resource protection |
+
+For additional rate limiting, consider:
+- fail2ban at the network level
+- iptables rate limiting rules
+- Application-level rate limiting middleware
+
+### Attack Scenarios
+
+#### Scenario 1: Simple Brute Force
+
+**Attack:** Single IP tries many passwords
+
+**Protection:** ✅ Blocked after threshold attempts
+
+#### Scenario 2: Distributed Brute Force
+
+**Attack:** Many IPs each try a few passwords
+
+**Protection:** ⚠️ Partially protected (each IP tracked independently)
+
+**Mitigation:** 
+- Lower threshold for stricter blocking
+- Add account-level lockout (separate feature)
+- Use external threat intelligence
+
+#### Scenario 3: Credential Stuffing
+
+**Attack:** Valid credentials from other breaches
+
+**Protection:** ⚠️ Limited (may succeed before threshold)
+
+**Mitigation:**
+- Enable 2FA where possible
+- Monitor for unusual patterns
+- Integrate with breach databases
+
+## Performance
+
+### Memory Usage
+
+Per-IP overhead:
+- Failure counter: ~100 bytes
+- Block record: ~200 bytes
+
+Example: 10,000 IPs = ~3MB
+
+### Cache Hits
+
+- Check if blocked: 1 cache read
+- Record failure: 1 cache read + 1 cache write
+- Record success: 1 cache delete
+
+All operations are O(1) with proper cache backend.
+
+### Network Impact
+
+With Redis/Memcached:
+- ~50 bytes per operation
+- Sub-millisecond latency
+
+## Troubleshooting
+
+### Problem: Legitimate users being blocked
+
+**Symptoms:**
+- Users report "Too many authentication failures"
+- Metrics show many blocks
+
+**Solutions:**
+1. Increase `auth_failure_threshold`
+2. Decrease `auth_failure_block_duration`
+3. Check for misconfigured email clients
+4. Verify credentials are correct
+
+### Problem: Blocks not working
+
+**Symptoms:**
+- Attackers not being blocked
+- No entries in logs
+- Metrics not incrementing
+
+**Diagnostics:**
+1. Check Rails.cache is working: `Rails.cache.write("test", 1)`
+2. Verify configuration is loaded: `Postal::Config.smtp_server.auth_failure_threshold`
+3. Check logs for error messages
+4. Verify SMTP server process restarted after config change
+
+**Solutions:**
+1. Ensure cache backend is properly configured
+2. Check cache memory limits
+3. Verify configuration file syntax
+4. Restart SMTP server processes
+
+### Problem: Blocks persist after expiry
+
+**Symptoms:**
+- IPs still blocked after configured duration
+- `time_remaining_on_block` returns unexpected values
+
+**Solutions:**
+1. Check cache backend TTL handling
+2. Manually unblock: `SMTPServer::AuthFailureTracker.unblock(ip)`
+3. Clear entire cache: `Rails.cache.clear` (affects all cached data)
+
+## Monitoring
+
+### Key Metrics
+
+Monitor these Prometheus metrics:
+
+```promql
+# Blocks per hour
+rate(postal_smtp_server_auth_blocks_total[1h])
+
+# Failed auth attempts
+rate(postal_smtp_server_client_errors{error="invalid-credentials"}[5m])
+
+# Blocked attempts
+rate(postal_smtp_server_client_errors{error="ip-blocked"}[5m])
+```
+
+### Alerting Rules
+
+Example Prometheus alerts:
+
+```yaml
+groups:
+  - name: smtp_security
+    rules:
+      - alert: HighAuthFailureRate
+        expr: rate(postal_smtp_server_client_errors{error="invalid-credentials"}[5m]) > 10
+        for: 5m
+        annotations:
+          summary: High SMTP authentication failure rate
+
+      - alert: ManyBlockedIPs
+        expr: rate(postal_smtp_server_auth_blocks_total[1h]) > 5
+        for: 10m
+        annotations:
+          summary: Many IP addresses being blocked
+```
+
+### Log Analysis
+
+Key log patterns:
+
+```
+Authentication failure for <IP>
+IP <IP> blocked after <N> failed authentication attempts
+Authentication blocked for <IP> - too many failed attempts
+```
+
+Use these for:
+- Security incident response
+- Attack pattern analysis
+- False positive identification
+
+## Future Enhancements
+
+Possible improvements:
+
+- [ ] IP whitelist/blacklist configuration
+- [ ] Progressive delays (exponential backoff)
+- [ ] Permanent blocking after excessive attempts
+- [ ] Dashboard UI for managing blocks
+- [ ] Email notifications for security events
+- [ ] Account-level lockout (independent of IP)
+- [ ] Integration with external threat intelligence
+- [ ] Geographic blocking rules
+- [ ] Custom block reasons and messages
+- [ ] API for managing blocks
+
+## References
+
+- [SMTP AUTH RFC 4954](https://tools.ietf.org/html/rfc4954)
+- [SMTP Response Codes RFC 5321](https://tools.ietf.org/html/rfc5321)
+- [User Documentation](../doc/SMTP_AUTH_BLOCKING.md)
+
+## Support
+
+For issues or questions:
+
+1. Check the logs: `docker logs postal-smtp-1` or check your log files
+2. Verify configuration: `Postal::Config.smtp_server.auth_failure_threshold`
+3. Check metrics: View Prometheus dashboard
+4. Review this README and user documentation
+5. Check existing GitHub issues
+6. Open a new issue with logs and configuration
+
+## License
+
+Part of the Postal mail server project.

--- a/app/lib/smtp_server/auth_failure_tracker.rb
+++ b/app/lib/smtp_server/auth_failure_tracker.rb
@@ -1,0 +1,342 @@
+# frozen_string_literal: true
+
+module SMTPServer
+  # Tracks authentication failures to detect and block brute force attacks.
+  # Uses Rails cache for fast counting within time windows and tracks both
+  # failure counts and active blocks.
+  #
+  # After X failed authentication attempts within a time window, the source IP
+  # is blocked for Y minutes. Both X (threshold) and Y (block duration) are
+  # configurable.
+  #
+  # @example Check if IP is blocked
+  #   tracker = SMTPServer::AuthFailureTracker.new(ip_address: "1.2.3.4")
+  #   if tracker.blocked?
+  #     # Reject connection
+  #   end
+  #
+  # @example Record a failed authentication attempt
+  #   tracker = SMTPServer::AuthFailureTracker.new(
+  #     ip_address: "1.2.3.4",
+  #     threshold: 5,
+  #     block_duration_minutes: 120
+  #   )
+  #
+  #   if tracker.record_failure_and_check_threshold
+  #     # Threshold exceeded, IP is now blocked
+  #     logger.warn "IP #{ip_address} blocked after #{threshold} failed attempts"
+  #   end
+  #
+  class AuthFailureTracker
+
+    attr_reader :ip_address, :threshold, :block_duration_minutes
+
+    # Default configuration
+    # After 5 failed attempts, block for 120 minutes (2 hours)
+    DEFAULT_THRESHOLD = 5
+    DEFAULT_BLOCK_DURATION_MINUTES = 120
+    DEFAULT_WINDOW_MINUTES = 15
+
+    # @param ip_address [String] The source IP address
+    # @param threshold [Integer] Number of failures to trigger block (default: 5)
+    # @param block_duration_minutes [Integer] How long to block the IP (default: 120)
+    # @param window_minutes [Integer] Time window for counting failures (default: 15)
+    #
+    def initialize(ip_address:, threshold: nil, block_duration_minutes: nil, window_minutes: nil)
+      @ip_address = ip_address
+      @threshold = threshold || config_threshold || DEFAULT_THRESHOLD
+      @block_duration_minutes = block_duration_minutes || config_block_duration || DEFAULT_BLOCK_DURATION_MINUTES
+      @window_minutes = window_minutes || DEFAULT_WINDOW_MINUTES
+    end
+
+    # Checks if the IP is currently blocked
+    #
+    # @return [Boolean] true if IP is blocked
+    #
+    def blocked?
+      Rails.cache.read(block_cache_key).present?
+    end
+
+    # Records a failed authentication attempt and checks if threshold is exceeded.
+    # If threshold is exceeded, blocks the IP.
+    #
+    # @return [Boolean] true if threshold is exceeded and IP is now blocked
+    #
+    def record_failure_and_check_threshold
+      increment_failure_counter
+      count = current_failure_count
+
+      if count >= @threshold
+        block_ip
+        true
+      else
+        false
+      end
+    end
+
+    # Records a failed authentication without checking threshold
+    #
+    # @return [Integer] The new failure count
+    #
+    def record_failure
+      increment_failure_counter
+      current_failure_count
+    end
+
+    # Gets the current count of failed attempts within the time window
+    #
+    # @return [Integer] The count
+    #
+    def current_failure_count
+      Rails.cache.read(failure_cache_key) || 0
+    end
+
+    # Records a successful authentication (clears failure counter)
+    #
+    # @return [Boolean] true if reset succeeded
+    #
+    def record_success
+      reset_failure_counter
+    end
+
+    # Blocks the IP address for the configured duration
+    #
+    # @return [Boolean] true if block was set
+    #
+    def block_ip
+      # Add IP to blocked index
+      add_to_blocked_index
+
+      Rails.cache.write(
+        block_cache_key,
+        {
+          ip_address: @ip_address,
+          blocked_at: Time.current.to_i,
+          failure_count: current_failure_count,
+          threshold: @threshold
+        },
+        expires_in: @block_duration_minutes.minutes
+      )
+    end
+
+    # Manually unblocks an IP address (e.g., for administrative override)
+    #
+    # @return [Boolean] true if unblock succeeded
+    #
+    def unblock_ip
+      # Remove from blocked index
+      remove_from_blocked_index
+
+      Rails.cache.delete(block_cache_key)
+    end
+
+    # Resets the failure counter
+    #
+    # @return [Boolean] true if reset succeeded
+    #
+    def reset_failure_counter
+      Rails.cache.delete(failure_cache_key)
+    end
+
+    # Gets block information if IP is blocked
+    #
+    # @return [Hash, nil] Block info hash with :blocked_at, :failure_count, :threshold, or nil
+    #
+    def block_info
+      Rails.cache.read(block_cache_key)
+    end
+
+    # Gets the time remaining on the block in seconds
+    #
+    # @return [Integer, nil] Seconds remaining, or nil if not blocked
+    #
+    def time_remaining_on_block
+      return nil unless blocked?
+
+      # Rails.cache doesn't provide direct TTL access, so we estimate
+      # based on blocked_at timestamp if available
+      info = block_info
+      return @block_duration_minutes * 60 unless info&.dig(:blocked_at)
+
+      elapsed = Time.current.to_i - info[:blocked_at]
+      remaining = (@block_duration_minutes * 60) - elapsed
+      [remaining, 0].max
+    end
+
+    # Class method to check if an IP is blocked
+    #
+    # @param ip_address [String]
+    # @return [Boolean]
+    #
+    def self.blocked?(ip_address)
+      new(ip_address: ip_address).blocked?
+    end
+
+    # Class method to record failure and check threshold
+    #
+    # @param ip_address [String]
+    # @param threshold [Integer]
+    # @param block_duration_minutes [Integer]
+    # @return [Boolean] true if IP is now blocked
+    #
+    def self.record_and_check(ip_address:, threshold: nil, block_duration_minutes: nil)
+      new(
+        ip_address: ip_address,
+        threshold: threshold,
+        block_duration_minutes: block_duration_minutes
+      ).record_failure_and_check_threshold
+    end
+
+    # Class method to unblock an IP
+    #
+    # @param ip_address [String]
+    # @return [Boolean]
+    #
+    def self.unblock(ip_address)
+      new(ip_address: ip_address).unblock_ip
+    end
+
+    # Class method to get all blocked IPs with their information
+    #
+    # @return [Array<Hash>] Array of hashes with IP info
+    #
+    def self.all_blocked
+      blocked_ips_set = Rails.cache.read(blocked_index_key) || []
+
+      blocked_ips_set.map do |ip|
+        tracker = new(ip_address: ip)
+        info = tracker.block_info
+
+        next nil unless info # Skip if expired
+
+        {
+          ip_address: ip,
+          blocked_at: Time.at(info[:blocked_at]),
+          failure_count: info[:failure_count],
+          threshold: info[:threshold],
+          expires_at: Time.at(info[:blocked_at]) + (tracker.block_duration_minutes * 60),
+          time_remaining: tracker.time_remaining_on_block
+        }
+      end.compact.sort_by { |b| -b[:blocked_at].to_i }
+    end
+
+    # Class method to search blocked IPs
+    #
+    # @param query [String] IP address or partial IP to search for
+    # @return [Array<Hash>] Array of matching blocked IPs
+    #
+    def self.search_blocked(query)
+      return all_blocked if query.blank?
+
+      all_blocked.select { |b| b[:ip_address].include?(query) }
+    end
+
+    # Class method to clean expired entries from blocked index
+    #
+    # @return [Integer] Number of cleaned entries
+    #
+    def self.cleanup_blocked_index
+      blocked_ips_set = Rails.cache.read(blocked_index_key) || []
+      cleaned = 0
+
+      blocked_ips_set.reject! do |ip|
+        tracker = new(ip_address: ip)
+        is_expired = !tracker.blocked?
+        cleaned += 1 if is_expired
+        is_expired
+      end
+
+      Rails.cache.write(blocked_index_key, blocked_ips_set)
+      cleaned
+    end
+
+    # Cache key for the blocked IPs index
+    #
+    # @return [String]
+    #
+    def self.blocked_index_key
+      "smtp_auth:blocked_index:v1"
+    end
+
+    private
+
+    # Generates the cache key for failure counting
+    #
+    # @return [String]
+    #
+    def failure_cache_key
+      # Hash IP to prevent cache key manipulation and normalize length
+      ip_hash = Digest::SHA256.hexdigest(@ip_address.to_s)
+      "smtp_auth:failures:v1:#{ip_hash}"
+    end
+
+    # Generates the cache key for blocking
+    #
+    # @return [String]
+    #
+    def block_cache_key
+      # Hash IP to prevent cache key manipulation and normalize length
+      ip_hash = Digest::SHA256.hexdigest(@ip_address.to_s)
+      "smtp_auth:blocked:v1:#{ip_hash}"
+    end
+
+    # Increments the failure counter with expiry
+    #
+    # @return [Integer] The new count
+    #
+    def increment_failure_counter
+      current = Rails.cache.read(failure_cache_key) || 0
+      new_value = current + 1
+
+      # Set with expiry to auto-expire old counters
+      Rails.cache.write(failure_cache_key, new_value, expires_in: @window_minutes.minutes)
+
+      new_value
+    end
+
+    # Reads threshold from configuration
+    #
+    # @return [Integer, nil]
+    #
+    def config_threshold
+      return nil unless defined?(Postal::Config)
+
+      Postal::Config.smtp_server&.auth_failure_threshold
+    rescue StandardError
+      nil
+    end
+
+    # Reads block duration from configuration
+    #
+    # @return [Integer, nil]
+    #
+    def config_block_duration
+      return nil unless defined?(Postal::Config)
+
+      Postal::Config.smtp_server&.auth_failure_block_duration
+    rescue StandardError
+      nil
+    end
+
+    # Adds IP to the blocked index
+    #
+    # @return [Boolean]
+    #
+    def add_to_blocked_index
+      blocked_ips_set = Rails.cache.read(self.class.blocked_index_key) || []
+      blocked_ips_set << @ip_address unless blocked_ips_set.include?(@ip_address)
+      Rails.cache.write(self.class.blocked_index_key, blocked_ips_set)
+    end
+
+    # Removes IP from the blocked index
+    #
+    # @return [Boolean]
+    #
+    def remove_from_blocked_index
+      blocked_ips_set = Rails.cache.read(self.class.blocked_index_key) || []
+      blocked_ips_set.delete(@ip_address)
+      Rails.cache.write(self.class.blocked_index_key, blocked_ips_set)
+    end
+
+  end
+end

--- a/app/lib/smtp_server/client.rb
+++ b/app/lib/smtp_server/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "auth_failure_tracker"
+
 module SMTPServer
   class Client
 
@@ -113,6 +115,12 @@ module SMTPServer
       @logger ||= Postal.logger.create_tagged_logger(trace_id: trace_id)
     end
 
+    def auth_failure_tracker
+      return nil unless @ip_address
+
+      @auth_failure_tracker ||= AuthFailureTracker.new(ip_address: @ip_address)
+    end
+
     private
 
     def proxy(data)
@@ -182,6 +190,13 @@ module SMTPServer
     def auth_plain(data)
       increment_command_count("AUTH PLAIN")
 
+      # Check if IP is blocked before processing authentication
+      if auth_failure_tracker&.blocked?
+        increment_error_count("ip-blocked")
+        logger&.warn "Authentication blocked for #{@ip_address} - too many failed attempts"
+        return "421 Too many authentication failures. Try again later."
+      end
+
       handler = proc do |idata|
         @proc = nil
         idata = Base64.decode64(idata)
@@ -209,6 +224,13 @@ module SMTPServer
     def auth_login(data)
       increment_command_count("AUTH LOGIN")
 
+      # Check if IP is blocked before processing authentication
+      if auth_failure_tracker&.blocked?
+        increment_error_count("ip-blocked")
+        logger&.warn "Authentication blocked for #{@ip_address} - too many failed attempts"
+        return "421 Too many authentication failures. Try again later."
+      end
+
       password_handler = proc do |idata|
         @proc = nil
         password = Base64.decode64(idata)
@@ -233,16 +255,32 @@ module SMTPServer
     def authenticate(password)
       if @credential = Credential.where(type: "SMTP", key: password).first
         @credential.use
+        # Reset failure counter on successful authentication
+        auth_failure_tracker&.record_success
         "235 Granted for #{@credential.server.organization.permalink}/#{@credential.server.permalink}"
       else
         logger&.warn "Authentication failure for #{@ip_address}"
         increment_error_count("invalid-credentials")
+
+        # Track the failed attempt and check if we should block
+        if auth_failure_tracker&.record_failure_and_check_threshold
+          increment_prometheus_counter(:postal_smtp_server_auth_blocks_total)
+          logger&.warn "IP #{@ip_address} blocked after #{auth_failure_tracker.threshold} failed authentication attempts"
+        end
+
         "535 Invalid credential"
       end
     end
 
     def auth_cram_md5(data)
       increment_command_count("AUTH CRAM-MD5")
+
+      # Check if IP is blocked before processing authentication
+      if auth_failure_tracker&.blocked?
+        increment_error_count("ip-blocked")
+        logger&.warn "Authentication blocked for #{@ip_address} - too many failed attempts"
+        return "421 Too many authentication failures. Try again later."
+      end
 
       challenge = Digest::SHA1.hexdigest(Time.now.to_i.to_s + rand(100_000).to_s)
       challenge = "<#{challenge[0, 20]}@#{Postal::Config.postal.smtp_hostname}>"
@@ -255,6 +293,13 @@ module SMTPServer
         if server.nil?
           logger&.warn "Authentication failure for #{@ip_address} (no server found matching #{username})"
           increment_error_count("invalid-credentials")
+
+          # Track the failed attempt
+          if auth_failure_tracker&.record_failure_and_check_threshold
+            increment_prometheus_counter(:postal_smtp_server_auth_blocks_total)
+            logger&.warn "IP #{@ip_address} blocked after #{auth_failure_tracker.threshold} failed authentication attempts"
+          end
+
           next "535 Denied"
         end
 
@@ -273,7 +318,17 @@ module SMTPServer
         if grant.nil?
           logger&.warn "Authentication failure for #{@ip_address} (invalid credential)"
           increment_error_count("invalid-credentials")
+
+          # Track the failed attempt
+          if auth_failure_tracker&.record_failure_and_check_threshold
+            increment_prometheus_counter(:postal_smtp_server_auth_blocks_total)
+            logger&.warn "IP #{@ip_address} blocked after #{auth_failure_tracker.threshold} failed authentication attempts"
+          end
+
           next "535 Denied"
+        else
+          # Reset failure counter on successful authentication
+          auth_failure_tracker&.record_success
         end
 
         grant
@@ -589,6 +644,10 @@ module SMTPServer
         register_prometheus_counter :postal_smtp_server_messages_total,
                                     docstring: "The number of messages accepted by the SMTP server",
                                     labels: [:type, :tls]
+
+        register_prometheus_counter :postal_smtp_server_auth_blocks_total,
+                                    docstring: "The number of IP addresses blocked due to failed authentication attempts",
+                                    labels: []
       end
 
     end

--- a/app/views/admin_blocked_ips/index.html.haml
+++ b/app/views/admin_blocked_ips/index.html.haml
@@ -1,0 +1,112 @@
+- page_title << "Blocked IPs"
+
+.pageHeader
+  %h1.pageHeader__title SMTP Blocked IP Addresses
+  %p.pageHeader__intro IP addresses blocked due to failed authentication attempts
+
+.pageContent
+  .pageActions
+    = form_tag admin_blocked_ips_path, method: :get, class: "searchForm" do
+      .searchForm__field
+        = text_field_tag :query, @query, placeholder: "Search IP address...", class: "searchForm__input"
+        = submit_tag "Search", class: "button button--primary"
+        - if @query.present?
+          = link_to "Clear", admin_blocked_ips_path, class: "button button--secondary"
+
+    .pageActions__buttons
+      - if @total_blocked > 0
+        = link_to "Cleanup Expired", cleanup_admin_blocked_ips_path, method: :post, class: "button button--secondary", data: { confirm: "This will remove expired entries from the index. Continue?" }
+        = link_to "Unblock All", unblock_all_admin_blocked_ips_path, method: :post, class: "button button--danger", data: { confirm: "Are you sure you want to unblock all #{@total_blocked} IP addresses?" }
+
+  - if @total_blocked.zero?
+    .noData
+      %p.noData__title
+        - if @query.present?
+          No blocked IPs found matching "#{@query}"
+        - else
+          No blocked IP addresses
+      %p.noData__text
+        - if @query.present?
+          Try a different search query or
+          = link_to "view all blocked IPs", admin_blocked_ips_path
+        - else
+          IP addresses will appear here after exceeding the authentication failure threshold.
+
+  - else
+    .statsBar
+      .statsBar__item
+        .statsBar__value= number_with_delimiter @total_blocked
+        .statsBar__label Total Blocked IPs
+
+    %table.dataTable
+      %thead
+        %tr
+          %th.dataTable__header IP Address
+          %th.dataTable__header.u-center Blocked At
+          %th.dataTable__header.u-center Failed Attempts
+          %th.dataTable__header.u-center Threshold
+          %th.dataTable__header.u-center Expires At
+          %th.dataTable__header.u-center Time Remaining
+          %th.dataTable__header.u-center Actions
+      %tbody
+        - @blocked_ips.each do |ip_info|
+          %tr.dataTable__row
+            %td.dataTable__cell
+              %code.ipAddress= ip_info[:ip_address]
+            %td.dataTable__cell.u-center
+              %span.timestamp{title: ip_info[:blocked_at].iso8601}
+                = time_ago_in_words(ip_info[:blocked_at])
+                ago
+            %td.dataTable__cell.u-center
+              %span.badge.badge--danger= ip_info[:failure_count]
+            %td.dataTable__cell.u-center
+              = ip_info[:threshold]
+            %td.dataTable__cell.u-center
+              %span.timestamp{title: ip_info[:expires_at].iso8601}
+                = ip_info[:expires_at].strftime("%Y-%m-%d %H:%M:%S")
+            %td.dataTable__cell.u-center
+              - if ip_info[:time_remaining] > 0
+                %span.timeRemaining= distance_of_time_in_words(ip_info[:time_remaining])
+              - else
+                %span.expired Expired
+            %td.dataTable__cell.u-center
+              = link_to "Unblock", unblock_admin_blocked_ips_path(ip: ip_info[:ip_address]), method: :post, class: "button button--small button--primary", data: { confirm: "Are you sure you want to unblock #{ip_info[:ip_address]}?" }
+
+    - if @total_pages > 1
+      .pagination
+        .pagination__info
+          Showing
+          = (@page - 1) * @per_page + 1
+          to
+          = [(@page * @per_page), @total_blocked].min
+          of
+          = number_with_delimiter @total_blocked
+          blocked IPs
+
+        .pagination__controls
+          - if @page > 1
+            = link_to "← Previous", admin_blocked_ips_path(page: @page - 1, query: @query), class: "pagination__link"
+          - else
+            %span.pagination__link.pagination__link--disabled ← Previous
+
+          %span.pagination__current
+            Page #{@page} of #{@total_pages}
+
+          - if @page < @total_pages
+            = link_to "Next →", admin_blocked_ips_path(page: @page + 1, query: @query), class: "pagination__link"
+          - else
+            %span.pagination__link.pagination__link--disabled Next →
+
+  .pageFooter
+    %p.pageFooter__info
+      %strong Configuration:
+      Threshold =
+      = SMTPServer::AuthFailureTracker::DEFAULT_THRESHOLD
+      failures,
+      Block Duration =
+      = SMTPServer::AuthFailureTracker::DEFAULT_BLOCK_DURATION_MINUTES
+      minutes
+    %p.pageFooter__links
+      = link_to "Documentation", "https://github.com/postalserver/postal/blob/main/doc/SMTP_AUTH_BLOCKING.md", target: "_blank", rel: "noopener"
+      |
+      = link_to "Admin Dashboard", admin_dashboard_path

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,6 +42,7 @@
           - if current_user.admin?
             %li.siteHeader__navItem= link_to "Admin Dashboard", admin_dashboard_path, :class => 'sideHeader__navItemLink'
             %li.siteHeader__navItem= link_to "MX Rate Limits", admin_mx_rate_limits_path, :class => 'sideHeader__navItemLink'
+            %li.siteHeader__navItem= link_to "Blocked IPs", admin_blocked_ips_path, :class => 'sideHeader__navItemLink'
             - if Postal.ip_pools?
               %li.siteHeader__navItem= link_to "IP Pools", ip_pools_path, :class => 'sideHeader__navItemLink'
               %li.siteHeader__navItem= link_to "IP Reputation", dashboard_ip_reputation_index_path, :class => 'sideHeader__navItemLink'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,12 @@ Rails.application.routes.draw do
   get "admin/dashboard" => "admin_dashboard#index", as: "admin_dashboard"
   get "admin/mx_rate_limits" => "admin_mx_rate_limits#index", as: "admin_mx_rate_limits"
 
+  # Admin Blocked IPs
+  get "admin/blocked_ips" => "admin_blocked_ips#index", as: "admin_blocked_ips"
+  post "admin/blocked_ips/unblock" => "admin_blocked_ips#unblock", as: "unblock_admin_blocked_ips"
+  post "admin/blocked_ips/unblock_all" => "admin_blocked_ips#unblock_all", as: "unblock_all_admin_blocked_ips"
+  post "admin/blocked_ips/cleanup" => "admin_blocked_ips#cleanup", as: "cleanup_admin_blocked_ips"
+
   # IP Reputation Management (Phase 8)
   resources :ip_reputation, only: [:index] do
     collection do

--- a/doc/SMTP_AUTH_BLOCKING.md
+++ b/doc/SMTP_AUTH_BLOCKING.md
@@ -1,0 +1,261 @@
+# SMTP Authentication Failure Blocking
+
+Postal includes a built-in system to protect against brute force attacks on SMTP authentication. This system automatically blocks IP addresses that exceed a threshold of failed authentication attempts.
+
+## How It Works
+
+When an IP address fails to authenticate via SMTP (using AUTH PLAIN, AUTH LOGIN, or AUTH CRAM-MD5), the system tracks the number of failures. Once the configured threshold is reached, that IP address is temporarily blocked from making further authentication attempts.
+
+### Key Features
+
+- **Automatic blocking**: IP addresses are automatically blocked after exceeding the failure threshold
+- **Temporary blocks**: Blocks expire after a configurable duration
+- **Cross-method tracking**: Failures are tracked across all authentication methods (PLAIN, LOGIN, CRAM-MD5)
+- **Per-IP tracking**: Each IP address is tracked independently
+- **Automatic reset**: The failure counter is reset upon successful authentication
+- **Prometheus metrics**: Blocked IPs are tracked with Prometheus metrics for monitoring
+- **Detailed logging**: All blocks and failures are logged for security auditing
+
+## Configuration
+
+The system can be configured using either environment variables or the YAML configuration file.
+
+### Environment Variables
+
+```bash
+# Number of failed authentication attempts before blocking (default: 5)
+SMTP_SERVER__AUTH_FAILURE_THRESHOLD=5
+
+# Duration to block IP in minutes (default: 120 minutes = 2 hours)
+SMTP_SERVER__AUTH_FAILURE_BLOCK_DURATION=120
+```
+
+### YAML Configuration
+
+In your `postal.yml` file, under the `smtp_server` section:
+
+```yaml
+version: 2
+
+smtp_server:
+  # Number of failed authentication attempts before blocking (default: 5)
+  auth_failure_threshold: 5
+  
+  # Duration to block IP in minutes (default: 120 minutes = 2 hours)
+  auth_failure_block_duration: 120
+```
+
+## Default Values
+
+If not configured, the system uses these defaults:
+
+- **Threshold**: 5 failed attempts
+- **Block Duration**: 120 minutes (2 hours)
+
+## Examples
+
+### Example 1: Strict Security (Low Threshold, Long Block)
+
+Suitable for high-security environments where you want to be aggressive about blocking potential attackers:
+
+```yaml
+smtp_server:
+  auth_failure_threshold: 3      # Block after 3 failures
+  auth_failure_block_duration: 240  # Block for 4 hours
+```
+
+### Example 2: Lenient Configuration (High Threshold, Short Block)
+
+Suitable for environments where legitimate users might occasionally mistype passwords:
+
+```yaml
+smtp_server:
+  auth_failure_threshold: 10     # Block after 10 failures
+  auth_failure_block_duration: 30   # Block for 30 minutes
+```
+
+### Example 3: Balanced Security (Recommended)
+
+The default configuration provides a good balance:
+
+```yaml
+smtp_server:
+  auth_failure_threshold: 5      # Block after 5 failures
+  auth_failure_block_duration: 120  # Block for 2 hours
+```
+
+## SMTP Response Codes
+
+When an IP is blocked, clients receive this response:
+
+```
+421 Too many authentication failures. Try again later.
+```
+
+The `421` code is a standard SMTP temporary failure code, indicating that the service is temporarily unavailable.
+
+## Behavior Details
+
+### Failure Tracking
+
+- Failures are tracked across all authentication methods (PLAIN, LOGIN, CRAM-MD5)
+- Each failed authentication attempt increments the counter for that IP address
+- The counter is stored with an automatic expiry (default: 15 minutes window)
+- If no more failures occur within the window, the counter naturally expires
+
+### Successful Authentication
+
+- A successful authentication immediately resets the failure counter to 0
+- This prevents legitimate users from being blocked if they occasionally mistype a password
+
+### Multiple Connections
+
+- Blocks are per-IP address, not per-connection
+- If an IP is blocked, all new connections from that IP will be rejected
+- The block applies even if the client disconnects and reconnects
+
+### Independent IP Tracking
+
+- Each IP address is tracked completely independently
+- Blocking one IP does not affect other IPs
+- This prevents one attacker from causing collateral blocking
+
+## Monitoring
+
+### Prometheus Metrics
+
+The system exports the following Prometheus metrics:
+
+```
+# Counter: Number of IP addresses blocked due to failed authentication
+postal_smtp_server_auth_blocks_total
+
+# Counter: Number of times blocked IPs attempted authentication
+postal_smtp_server_client_errors{error="ip-blocked"}
+
+# Counter: Failed authentication attempts (before blocking)
+postal_smtp_server_client_errors{error="invalid-credentials"}
+```
+
+### Log Messages
+
+The system logs important events:
+
+**When a failure is recorded:**
+```
+Authentication failure for 192.168.1.100
+```
+
+**When an IP is blocked:**
+```
+IP 192.168.1.100 blocked after 5 failed authentication attempts
+```
+
+**When a blocked IP attempts authentication:**
+```
+Authentication blocked for 192.168.1.100 - too many failed attempts
+```
+
+## Security Considerations
+
+### Cache Backend
+
+The blocking system uses Rails.cache for storage. For production deployments:
+
+- Ensure your cache backend (Memcached, Redis, etc.) is properly configured
+- The cache should be persistent across server restarts if possible
+- Consider cache memory limits to ensure space for blocking data
+
+### Whitelisting
+
+Currently, the system does not support IP whitelisting. If you need to whitelist certain IPs (e.g., monitoring systems), you can:
+
+1. Use IP-based authentication (SMTP-IP credentials) instead
+2. Modify the code to check against a whitelist before blocking
+
+### Distributed Deployments
+
+In distributed deployments with multiple SMTP servers:
+
+- Each server tracks failures independently unless using a shared cache backend
+- Use a shared cache backend (Redis, Memcached) to share block state across servers
+- This ensures an attacker cannot bypass blocks by connecting to different servers
+
+### Rate Limiting vs. Blocking
+
+This system is designed for brute force protection, not rate limiting:
+
+- **Brute force protection**: Blocks after X failures in a window
+- **Rate limiting**: Limits number of attempts per time period
+
+For rate limiting, consider using additional tools like fail2ban or iptables rate limiting.
+
+## Troubleshooting
+
+### Legitimate Users Are Being Blocked
+
+If legitimate users are being blocked too frequently:
+
+1. Increase the `auth_failure_threshold` value
+2. Decrease the `auth_failure_block_duration` value
+3. Check logs to identify why authentication is failing
+4. Verify credentials are correct in client applications
+
+### Blocks Are Not Working
+
+If attackers are not being blocked:
+
+1. Verify configuration is loaded correctly (check logs on startup)
+2. Ensure Rails.cache is working properly
+3. Check Prometheus metrics to see if blocks are being recorded
+4. Verify the SMTP server process is reading the configuration
+
+### Manual Unblocking
+
+To manually unblock an IP address, you can use Rails console:
+
+```ruby
+# In Rails console
+SMTPServer::AuthFailureTracker.unblock("192.168.1.100")
+```
+
+Or clear the entire cache (affects all blocks):
+
+```ruby
+Rails.cache.clear
+```
+
+## Implementation Details
+
+### Files Modified/Created
+
+- `app/lib/smtp_server/auth_failure_tracker.rb` - Main tracker class
+- `app/lib/smtp_server/client.rb` - Modified to integrate blocking
+- `lib/postal/config_schema.rb` - Added configuration options
+- `spec/lib/smtp_server/auth_failure_tracker_spec.rb` - Unit tests
+- `spec/lib/smtp_server/client/auth_blocking_spec.rb` - Integration tests
+
+### Cache Keys
+
+The system uses SHA-256 hashed cache keys for security:
+
+- Failure counter: `smtp_auth:failures:v1:<sha256_of_ip>`
+- Block status: `smtp_auth:blocked:v1:<sha256_of_ip>`
+
+Hashing prevents cache key manipulation and normalizes key length.
+
+## Future Enhancements
+
+Possible future improvements:
+
+- IP whitelist/blacklist configuration
+- Progressive delays (increase delay with each failure)
+- Permanent blocking after excessive failures
+- Dashboard UI for viewing and managing blocked IPs
+- Email notifications for security events
+- Integration with external threat intelligence feeds
+
+## References
+
+- SMTP AUTH RFC: https://tools.ietf.org/html/rfc4954
+- SMTP Response Codes: https://tools.ietf.org/html/rfc5321

--- a/doc/config/configuration.md
+++ b/doc/config/configuration.md
@@ -66,6 +66,17 @@ For detailed configuration options and examples, see:
 - `doc/MX_RATE_LIMITING_CONFIGURATION.md` - Complete MX rate limiting configuration guide
 - `doc/MX_RATE_LIMITING_SPECIFICATION.md` - Technical specification and algorithm details
 
+## SMTP Authentication Failure Blocking
+
+Postal includes built-in protection against brute force attacks on SMTP authentication. The system automatically blocks IP addresses after a configurable number of failed authentication attempts.
+
+For detailed information, see:
+- `doc/SMTP_AUTH_BLOCKING.md` - Complete SMTP authentication blocking guide
+
+Key configuration options:
+- `smtp_server.auth_failure_threshold` - Number of failures before blocking (default: 5)
+- `smtp_server.auth_failure_block_duration` - Block duration in minutes (default: 120)
+
 ## Legacy configuration
 
 Legacy configuration files from Postal v1 and v2 are still supported. If you wish to use a new configuration option that is not available in the legacy format, you will need to upgrade the file to version 2.

--- a/doc/config/smtp_auth_blocking_examples.yml
+++ b/doc/config/smtp_auth_blocking_examples.yml
@@ -1,0 +1,136 @@
+# Example Configuration for SMTP Authentication Failure Blocking
+
+# This file shows various configuration examples for the SMTP authentication
+# failure blocking system.
+
+# ============================================================================
+# Default Configuration (Balanced Security)
+# ============================================================================
+
+version: 2
+
+smtp_server:
+  # Block IP after 5 failed authentication attempts (default)
+  auth_failure_threshold: 5
+  
+  # Block for 120 minutes (2 hours) (default)
+  auth_failure_block_duration: 120
+
+# ============================================================================
+# Strict Security Configuration
+# ============================================================================
+# Use this for high-security environments where you want to be aggressive
+# about blocking potential attackers.
+
+# version: 2
+# 
+# smtp_server:
+#   # Block after just 3 failures
+#   auth_failure_threshold: 3
+#   
+#   # Block for 4 hours
+#   auth_failure_block_duration: 240
+
+# ============================================================================
+# Lenient Configuration
+# ============================================================================
+# Use this in environments where legitimate users might occasionally
+# mistype passwords or have misconfigured email clients.
+
+# version: 2
+# 
+# smtp_server:
+#   # Allow up to 10 failures before blocking
+#   auth_failure_threshold: 10
+#   
+#   # Block for only 30 minutes
+#   auth_failure_block_duration: 30
+
+# ============================================================================
+# Very Strict (For Known Attack Scenarios)
+# ============================================================================
+# Use this temporarily during active attacks or in extremely high-security
+# environments.
+
+# version: 2
+# 
+# smtp_server:
+#   # Block after 2 failures
+#   auth_failure_threshold: 2
+#   
+#   # Block for 24 hours
+#   auth_failure_block_duration: 1440
+
+# ============================================================================
+# Development/Testing Configuration
+# ============================================================================
+# Use this during development to test the blocking behavior more easily.
+
+# version: 2
+# 
+# smtp_server:
+#   # Block after 3 attempts (easy to trigger)
+#   auth_failure_threshold: 3
+#   
+#   # Block for only 5 minutes (easy to wait out)
+#   auth_failure_block_duration: 5
+
+# ============================================================================
+# Environment Variable Configuration
+# ============================================================================
+# Instead of using YAML, you can configure via environment variables:
+#
+# SMTP_SERVER__AUTH_FAILURE_THRESHOLD=5
+# SMTP_SERVER__AUTH_FAILURE_BLOCK_DURATION=120
+#
+# Environment variables take precedence over YAML configuration.
+
+# ============================================================================
+# Complete SMTP Server Configuration Example
+# ============================================================================
+
+version: 2
+
+smtp_server:
+  # Port and binding
+  default_port: 25
+  default_bind_address: "::"
+  
+  # TLS configuration
+  tls_enabled: true
+  tls_certificate_path: "$config-file-root/smtp.cert"
+  tls_private_key_path: "$config-file-root/smtp.key"
+  
+  # Message size limit (in MB)
+  max_message_size: 14
+  
+  # Authentication failure blocking
+  auth_failure_threshold: 5
+  auth_failure_block_duration: 120
+  
+  # Connection logging
+  log_connections: true
+  
+  # Health server
+  default_health_server_port: 9091
+  default_health_server_bind_address: "127.0.0.1"
+
+# ============================================================================
+# Monitoring
+# ============================================================================
+# Monitor these Prometheus metrics:
+#
+# postal_smtp_server_auth_blocks_total
+#   - Total number of IPs blocked
+#
+# postal_smtp_server_client_errors{error="ip-blocked"}
+#   - Number of blocked authentication attempts
+#
+# postal_smtp_server_client_errors{error="invalid-credentials"}
+#   - Number of failed authentication attempts
+#
+# Set up alerts:
+#
+# - Alert if blocking rate is high (indicates ongoing attack)
+# - Alert if failure rate is high (indicates misconfiguration or attack)
+# - Alert if specific IPs are frequently blocked (investigate those IPs)

--- a/lib/postal/config_schema.rb
+++ b/lib/postal/config_schema.rb
@@ -415,6 +415,16 @@ module Postal
       string :log_ip_address_exclusion_matcher do
         description "A regular expression to use to exclude connections from logging"
       end
+
+      integer :auth_failure_threshold do
+        description "Number of failed authentication attempts before blocking an IP address"
+        default 5
+      end
+
+      integer :auth_failure_block_duration do
+        description "Duration in minutes to block an IP address after exceeding the authentication failure threshold"
+        default 120
+      end
     end
 
     group :dns do

--- a/spec/controllers/admin_blocked_ips_controller_spec.rb
+++ b/spec/controllers/admin_blocked_ips_controller_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminBlockedIpsController, type: :controller do
+  let(:admin_user) { create(:user, admin: true) }
+
+  before do
+    Rails.cache.clear
+    # Mock authentication
+    allow(controller).to receive(:login_required).and_return(true)
+    allow(controller).to receive(:logged_in?).and_return(true)
+    allow(controller).to receive(:current_user).and_return(admin_user)
+    allow(controller).to receive(:admin_required).and_return(true)
+  end
+
+  describe "GET #index" do
+    it "renders successfully" do
+      get :index
+      expect(response).to be_successful
+    end
+
+    it "handles search query parameter" do
+      get :index, params: { query: "192.168" }
+      expect(response).to be_successful
+    end
+
+    it "handles pagination parameter" do
+      get :index, params: { page: 2 }
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST #unblock" do
+    let(:blocked_ip) { "192.168.1.100" }
+
+    before do
+      # Block an IP
+      tracker = SMTPServer::AuthFailureTracker.new(ip_address: blocked_ip, threshold: 3)
+      3.times { tracker.record_failure }
+      tracker.block_ip
+    end
+
+    it "unblocks the specified IP" do
+      expect(SMTPServer::AuthFailureTracker.blocked?(blocked_ip)).to be true
+
+      post :unblock, params: { ip: blocked_ip }
+
+      expect(SMTPServer::AuthFailureTracker.blocked?(blocked_ip)).to be false
+      expect(flash[:notice]).to include("unblocked successfully")
+      expect(response).to redirect_to(admin_blocked_ips_path)
+    end
+
+    it "shows error for missing IP parameter" do
+      post :unblock, params: { ip: "" }
+
+      expect(flash[:error]).to include("IP address is required")
+      expect(response).to redirect_to(admin_blocked_ips_path)
+    end
+  end
+
+  describe "POST #unblock_all" do
+    before do
+      # Block multiple IPs
+      3.times do |i|
+        ip = "192.168.1.#{100 + i}"
+        tracker = SMTPServer::AuthFailureTracker.new(ip_address: ip, threshold: 3)
+        3.times { tracker.record_failure }
+        tracker.block_ip
+      end
+    end
+
+    it "unblocks all IPs" do
+      expect(SMTPServer::AuthFailureTracker.all_blocked.size).to eq(3)
+
+      post :unblock_all
+
+      expect(SMTPServer::AuthFailureTracker.all_blocked.size).to eq(0)
+      expect(flash[:notice]).to include("Successfully unblocked 3 IP address")
+      expect(response).to redirect_to(admin_blocked_ips_path)
+    end
+  end
+
+  describe "POST #cleanup" do
+    before do
+      # Block an IP
+      tracker = SMTPServer::AuthFailureTracker.new(ip_address: "192.168.1.100", threshold: 3)
+      3.times { tracker.record_failure }
+      tracker.block_ip
+
+      # Add expired entry to index (manually add IP without actual block)
+      index = Rails.cache.read(SMTPServer::AuthFailureTracker.blocked_index_key) || []
+      index << "10.0.0.1" # This IP is not actually blocked
+      Rails.cache.write(SMTPServer::AuthFailureTracker.blocked_index_key, index)
+    end
+
+    it "cleans up expired entries" do
+      post :cleanup
+
+      expect(flash[:notice]).to match(/Cleaned up \d+ expired/)
+      expect(response).to redirect_to(admin_blocked_ips_path)
+    end
+  end
+end

--- a/spec/lib/smtp_server/auth_failure_tracker_spec.rb
+++ b/spec/lib/smtp_server/auth_failure_tracker_spec.rb
@@ -1,0 +1,432 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SMTPServer
+
+  describe AuthFailureTracker do
+    let(:ip_address) { "192.168.1.100" }
+    let(:threshold) { 3 }
+    let(:block_duration) { 60 }
+
+    subject(:tracker) do
+      described_class.new(
+        ip_address: ip_address,
+        threshold: threshold,
+        block_duration_minutes: block_duration
+      )
+    end
+
+    before do
+      # Clear cache before each test
+      Rails.cache.clear
+    end
+
+    describe "#blocked?" do
+      context "when IP is not blocked" do
+        it "returns false" do
+          expect(tracker.blocked?).to be false
+        end
+      end
+
+      context "when IP is blocked" do
+        before do
+          tracker.block_ip
+        end
+
+        it "returns true" do
+          expect(tracker.blocked?).to be true
+        end
+      end
+    end
+
+    describe "#record_failure" do
+      it "increments the failure counter" do
+        expect { tracker.record_failure }.to change { tracker.current_failure_count }.from(0).to(1)
+      end
+
+      it "increments counter multiple times" do
+        tracker.record_failure
+        tracker.record_failure
+        expect(tracker.current_failure_count).to eq(2)
+      end
+    end
+
+    describe "#record_failure_and_check_threshold" do
+      context "when threshold is not exceeded" do
+        it "returns false" do
+          expect(tracker.record_failure_and_check_threshold).to be false
+        end
+
+        it "does not block the IP" do
+          tracker.record_failure_and_check_threshold
+          expect(tracker.blocked?).to be false
+        end
+      end
+
+      context "when threshold is exceeded" do
+        before do
+          (threshold - 1).times { tracker.record_failure }
+        end
+
+        it "returns true on the threshold attempt" do
+          expect(tracker.record_failure_and_check_threshold).to be true
+        end
+
+        it "blocks the IP" do
+          tracker.record_failure_and_check_threshold
+          expect(tracker.blocked?).to be true
+        end
+      end
+
+      context "when threshold is exactly met" do
+        before do
+          (threshold - 1).times { tracker.record_failure }
+        end
+
+        it "blocks on exactly the threshold number" do
+          expect(tracker.record_failure_and_check_threshold).to be true
+          expect(tracker.blocked?).to be true
+        end
+      end
+    end
+
+    describe "#record_success" do
+      before do
+        tracker.record_failure
+        tracker.record_failure
+      end
+
+      it "resets the failure counter" do
+        tracker.record_success
+        expect(tracker.current_failure_count).to eq(0)
+      end
+
+      it "prevents blocking after reset" do
+        tracker.record_success
+        tracker.record_failure
+        tracker.record_failure
+        expect(tracker.blocked?).to be false
+      end
+    end
+
+    describe "#block_ip" do
+      it "blocks the IP" do
+        tracker.block_ip
+        expect(tracker.blocked?).to be true
+      end
+
+      it "stores block information" do
+        tracker.record_failure
+        tracker.record_failure
+        tracker.block_ip
+
+        info = tracker.block_info
+        expect(info).to include(:blocked_at, :failure_count, :threshold)
+        expect(info[:failure_count]).to eq(2)
+        expect(info[:threshold]).to eq(threshold)
+      end
+    end
+
+    describe "#unblock_ip" do
+      before do
+        tracker.block_ip
+      end
+
+      it "unblocks the IP" do
+        tracker.unblock_ip
+        expect(tracker.blocked?).to be false
+      end
+
+      it "removes block information" do
+        tracker.unblock_ip
+        expect(tracker.block_info).to be_nil
+      end
+    end
+
+    describe "#reset_failure_counter" do
+      before do
+        tracker.record_failure
+        tracker.record_failure
+      end
+
+      it "resets the counter to 0" do
+        tracker.reset_failure_counter
+        expect(tracker.current_failure_count).to eq(0)
+      end
+    end
+
+    describe "#time_remaining_on_block" do
+      context "when IP is not blocked" do
+        it "returns nil" do
+          expect(tracker.time_remaining_on_block).to be_nil
+        end
+      end
+
+      context "when IP is blocked" do
+        before do
+          tracker.block_ip
+        end
+
+        it "returns a positive number of seconds" do
+          remaining = tracker.time_remaining_on_block
+          expect(remaining).to be > 0
+          expect(remaining).to be <= (block_duration * 60)
+        end
+      end
+    end
+
+    describe "class methods" do
+      describe ".blocked?" do
+        it "returns false for unblocked IP" do
+          expect(described_class.blocked?(ip_address)).to be false
+        end
+
+        it "returns true for blocked IP" do
+          tracker.block_ip
+          expect(described_class.blocked?(ip_address)).to be true
+        end
+      end
+
+      describe ".record_and_check" do
+        it "records failure and returns true when threshold exceeded" do
+          (threshold - 1).times do
+            described_class.record_and_check(
+              ip_address: ip_address,
+              threshold: threshold,
+              block_duration_minutes: block_duration
+            )
+          end
+
+          result = described_class.record_and_check(
+            ip_address: ip_address,
+            threshold: threshold,
+            block_duration_minutes: block_duration
+          )
+
+          expect(result).to be true
+          expect(described_class.blocked?(ip_address)).to be true
+        end
+      end
+
+      describe ".unblock" do
+        before do
+          tracker.block_ip
+        end
+
+        it "unblocks the IP" do
+          described_class.unblock(ip_address)
+          expect(described_class.blocked?(ip_address)).to be false
+        end
+      end
+    end
+
+    describe "cache key security" do
+      it "hashes IP addresses to prevent manipulation" do
+        key = tracker.send(:failure_cache_key)
+        expect(key).not_to include(ip_address)
+        expect(key).to match(/^smtp_auth:failures:v1:[a-f0-9]{64}$/)
+      end
+
+      it "generates different keys for different IPs" do
+        tracker1 = described_class.new(ip_address: "1.2.3.4")
+        tracker2 = described_class.new(ip_address: "5.6.7.8")
+
+        expect(tracker1.send(:failure_cache_key)).not_to eq(tracker2.send(:failure_cache_key))
+      end
+    end
+
+    describe "integration with config" do
+      context "when config values are set" do
+        before do
+          allow(Postal::Config).to receive(:smtp_server).and_return(
+            double(
+              auth_failure_threshold: 10,
+              auth_failure_block_duration: 240
+            )
+          )
+        end
+
+        it "uses config values when not explicitly provided" do
+          tracker = described_class.new(ip_address: ip_address)
+          expect(tracker.threshold).to eq(10)
+          expect(tracker.block_duration_minutes).to eq(240)
+        end
+      end
+
+      context "when explicit values override config" do
+        before do
+          allow(Postal::Config).to receive(:smtp_server).and_return(
+            double(
+              auth_failure_threshold: 10,
+              auth_failure_block_duration: 240
+            )
+          )
+        end
+
+        it "uses explicit values" do
+          tracker = described_class.new(
+            ip_address: ip_address,
+            threshold: 5,
+            block_duration_minutes: 120
+          )
+          expect(tracker.threshold).to eq(5)
+          expect(tracker.block_duration_minutes).to eq(120)
+        end
+      end
+
+      context "when config is not available" do
+        before do
+          allow(Postal::Config).to receive(:smtp_server).and_raise(StandardError)
+        end
+
+        it "uses default values" do
+          tracker = described_class.new(ip_address: ip_address)
+          expect(tracker.threshold).to eq(described_class::DEFAULT_THRESHOLD)
+          expect(tracker.block_duration_minutes).to eq(described_class::DEFAULT_BLOCK_DURATION_MINUTES)
+        end
+      end
+    end
+
+    describe "blocked IP index management" do
+      let(:ip1) { "192.168.1.100" }
+      let(:ip2) { "192.168.1.101" }
+      let(:ip3) { "192.168.1.102" }
+
+      describe ".all_blocked" do
+        context "with no blocked IPs" do
+          it "returns empty array" do
+            expect(described_class.all_blocked).to eq([])
+          end
+        end
+
+        context "with blocked IPs" do
+          before do
+            # Block multiple IPs
+            [ip1, ip2, ip3].each do |ip|
+              tracker = described_class.new(ip_address: ip, threshold: 3, block_duration_minutes: 60)
+              3.times { tracker.record_failure }
+              tracker.block_ip
+            end
+          end
+
+          it "returns all blocked IPs" do
+            blocked = described_class.all_blocked
+            expect(blocked.size).to eq(3)
+            expect(blocked.map { |b| b[:ip_address] }).to match_array([ip1, ip2, ip3])
+          end
+
+          it "includes block information" do
+            blocked = described_class.all_blocked.first
+            expect(blocked).to include(:ip_address, :blocked_at, :failure_count, :threshold, :expires_at, :time_remaining)
+            expect(blocked[:blocked_at]).to be_a(Time)
+            expect(blocked[:expires_at]).to be_a(Time)
+          end
+
+          it "sorts by blocked_at descending (newest first)" do
+            # Block another IP after a short delay
+            sleep 1
+            ip4 = "192.168.1.103"
+            tracker = described_class.new(ip_address: ip4, threshold: 3)
+            3.times { tracker.record_failure }
+            tracker.block_ip
+
+            blocked = described_class.all_blocked
+            expect(blocked.first[:ip_address]).to eq(ip4)
+          end
+
+          it "excludes expired entries" do
+            # Manually unblock one
+            described_class.unblock(ip2)
+
+            blocked = described_class.all_blocked
+            expect(blocked.size).to eq(2)
+            expect(blocked.map { |b| b[:ip_address] }).not_to include(ip2)
+          end
+        end
+      end
+
+      describe ".search_blocked" do
+        before do
+          # Block IPs with different patterns
+          described_class.new(ip_address: "192.168.1.100", threshold: 3).tap do |t|
+            3.times { t.record_failure }
+            t.block_ip
+          end
+
+          described_class.new(ip_address: "10.0.0.50", threshold: 3).tap do |t|
+            3.times { t.record_failure }
+            t.block_ip
+          end
+
+          described_class.new(ip_address: "192.168.2.100", threshold: 3).tap do |t|
+            3.times { t.record_failure }
+            t.block_ip
+          end
+        end
+
+        it "returns all when query is blank" do
+          expect(described_class.search_blocked("").size).to eq(3)
+          expect(described_class.search_blocked(nil).size).to eq(3)
+        end
+
+        it "searches by partial IP" do
+          results = described_class.search_blocked("192.168.1")
+          expect(results.size).to eq(1)
+          expect(results.first[:ip_address]).to eq("192.168.1.100")
+        end
+
+        it "returns multiple matches" do
+          results = described_class.search_blocked("192.168")
+          expect(results.size).to eq(2)
+        end
+
+        it "returns empty for no matches" do
+          results = described_class.search_blocked("999.999")
+          expect(results).to be_empty
+        end
+      end
+
+      describe ".cleanup_blocked_index" do
+        before do
+          # Block some IPs
+          [ip1, ip2].each do |ip|
+            tracker = described_class.new(ip_address: ip, threshold: 3)
+            3.times { tracker.record_failure }
+            tracker.block_ip
+          end
+
+          # Manually add expired entry to index
+          index = Rails.cache.read(described_class.blocked_index_key) || []
+          index << ip3 # This IP is in index but not actually blocked
+          Rails.cache.write(described_class.blocked_index_key, index)
+        end
+
+        it "removes expired entries from index" do
+          cleaned = described_class.cleanup_blocked_index
+          expect(cleaned).to eq(1)
+
+          index = Rails.cache.read(described_class.blocked_index_key)
+          expect(index).to match_array([ip1, ip2])
+          expect(index).not_to include(ip3)
+        end
+
+        it "returns zero when no cleanup needed" do
+          # First cleanup
+          described_class.cleanup_blocked_index
+
+          # Second cleanup should find nothing
+          cleaned = described_class.cleanup_blocked_index
+          expect(cleaned).to eq(0)
+        end
+      end
+
+      describe "index key" do
+        it "has correct format" do
+          expect(described_class.blocked_index_key).to eq("smtp_auth:blocked_index:v1")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/smtp_server/client/auth_blocking_spec.rb
+++ b/spec/lib/smtp_server/client/auth_blocking_spec.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SMTPServer
+
+  describe Client, "authentication blocking" do
+    let(:ip_address) { "192.168.1.100" }
+    let(:threshold) { 3 }
+    let(:block_duration) { 60 }
+
+    subject(:client) { described_class.new(ip_address) }
+
+    before do
+      Rails.cache.clear
+      client.handle("HELO test.example.com")
+
+      # Mock config to use lower threshold for testing
+      allow(Postal::Config).to receive(:smtp_server).and_return(
+        double(
+          auth_failure_threshold: threshold,
+          auth_failure_block_duration: block_duration,
+          log_ip_address_exclusion_matcher: nil,
+          tls_enabled?: false
+        )
+      )
+    end
+
+    describe "AUTH PLAIN blocking" do
+      let(:invalid_auth) { Base64.encode64("user\0wrongpass") }
+
+      context "when failures are below threshold" do
+        it "allows authentication attempts" do
+          (threshold - 1).times do
+            response = client.handle("AUTH PLAIN #{invalid_auth}")
+            expect(response).to eq("535 Invalid credential")
+          end
+        end
+      end
+
+      context "when threshold is exceeded" do
+        before do
+          threshold.times do
+            client.handle("AUTH PLAIN #{invalid_auth}")
+          end
+        end
+
+        it "blocks further authentication attempts" do
+          response = client.handle("AUTH PLAIN")
+          expect(response).to eq("421 Too many authentication failures. Try again later.")
+        end
+
+        it "returns block message for any AUTH PLAIN attempt" do
+          # Create a new client with same IP to simulate new connection
+          new_client = described_class.new(ip_address)
+          new_client.handle("HELO test.example.com")
+
+          response = new_client.handle("AUTH PLAIN")
+          expect(response).to eq("421 Too many authentication failures. Try again later.")
+        end
+      end
+
+      context "when successful authentication occurs before threshold" do
+        it "resets the failure counter" do
+          # Fail twice
+          2.times { client.handle("AUTH PLAIN #{invalid_auth}") }
+
+          # Succeed once
+          credential = create(:credential, type: "SMTP")
+          response = client.handle("AUTH PLAIN #{credential.to_smtp_plain}")
+          expect(response).to match(/235 Granted for/)
+
+          # Should be able to fail again without being blocked
+          (threshold - 1).times do
+            response = client.handle("AUTH PLAIN #{invalid_auth}")
+            expect(response).to eq("535 Invalid credential")
+          end
+        end
+      end
+    end
+
+    describe "AUTH LOGIN blocking" do
+      context "when failures exceed threshold" do
+        before do
+          threshold.times do
+            client.handle("AUTH LOGIN")
+            client.handle("dXNlcm5hbWU=") # "username" in base64
+            client.handle("d3JvbmdwYXNz") # "wrongpass" in base64
+          end
+        end
+
+        it "blocks further authentication attempts" do
+          response = client.handle("AUTH LOGIN")
+          expect(response).to eq("421 Too many authentication failures. Try again later.")
+        end
+      end
+
+      context "with successful authentication" do
+        it "resets the counter" do
+          # Fail once
+          client.handle("AUTH LOGIN")
+          client.handle("dXNlcm5hbWU=")
+          client.handle("d3JvbmdwYXNz")
+
+          # Succeed
+          credential = create(:credential, type: "SMTP")
+          client.handle("AUTH LOGIN")
+          client.handle("dXNlcm5hbWU=")
+          password = Base64.encode64(credential.key)
+          response = client.handle(password)
+          expect(response).to match(/235 Granted for/)
+
+          # Counter should be reset
+          tracker = AuthFailureTracker.new(ip_address: ip_address)
+          expect(tracker.current_failure_count).to eq(0)
+        end
+      end
+    end
+
+    describe "AUTH CRAM-MD5 blocking" do
+      let(:server) { create(:server) }
+      let(:credential) { create(:credential, type: "SMTP", server: server) }
+
+      context "when failures exceed threshold" do
+        before do
+          threshold.times do
+            response = client.handle("AUTH CRAM-MD5")
+            # Extract challenge from response
+            challenge_b64 = response.sub(/^334 /, "")
+            # Send invalid response
+            client.handle(Base64.encode64("#{server.organization.permalink}/#{server.permalink} wronghmac"))
+          end
+        end
+
+        it "blocks further authentication attempts" do
+          response = client.handle("AUTH CRAM-MD5")
+          expect(response).to eq("421 Too many authentication failures. Try again later.")
+        end
+      end
+
+      context "with successful CRAM-MD5 authentication" do
+        it "resets the counter" do
+          # Fail once with wrong server
+          client.handle("AUTH CRAM-MD5")
+          client.handle(Base64.encode64("wrong/wrong wronghmac"))
+
+          # Succeed with valid CRAM-MD5
+          response = client.handle("AUTH CRAM-MD5")
+          challenge_b64 = response.sub(/^334 /, "")
+          challenge = Base64.decode64(challenge_b64)
+
+          hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("md5"), credential.key, challenge)
+          cram_response = "#{server.organization.permalink}/#{server.permalink} #{hmac}"
+          response = client.handle(Base64.encode64(cram_response))
+
+          expect(response).to match(/235 Granted for/)
+
+          # Counter should be reset
+          tracker = AuthFailureTracker.new(ip_address: ip_address)
+          expect(tracker.current_failure_count).to eq(0)
+        end
+      end
+    end
+
+    describe "multiple authentication methods" do
+      let(:invalid_plain) { Base64.encode64("user\0wrongpass") }
+
+      it "tracks failures across different auth methods" do
+        # Fail with PLAIN
+        client.handle("AUTH PLAIN #{invalid_plain}")
+
+        # Fail with LOGIN
+        client.handle("AUTH LOGIN")
+        client.handle("dXNlcm5hbWU=")
+        client.handle("d3JvbmdwYXNz")
+
+        # Fail with CRAM-MD5
+        client.handle("AUTH CRAM-MD5")
+        client.handle(Base64.encode64("wrong/wrong wronghmac"))
+
+        # Should now be blocked (3 failures with threshold of 3)
+        response = client.handle("AUTH PLAIN")
+        expect(response).to eq("421 Too many authentication failures. Try again later.")
+      end
+    end
+
+    describe "Prometheus metrics" do
+      let(:invalid_auth) { Base64.encode64("user\0wrongpass") }
+
+      it "increments block counter when threshold is exceeded" do
+        # The increment_prometheus_counter is called internally
+        # We can't easily test Prometheus counters in specs, but we verify
+        # the behavior by checking that blocking works correctly
+        (threshold + 1).times do
+          client.handle("AUTH PLAIN #{invalid_auth}")
+        end
+
+        # Verify that the IP is actually blocked
+        response = client.handle("AUTH PLAIN")
+        expect(response).to eq("421 Too many authentication failures. Try again later.")
+      end
+    end
+
+    describe "error counting" do
+      it "increments ip-blocked error count when blocked" do
+        invalid_auth = Base64.encode64("user\0wrongpass")
+
+        # Exceed threshold
+        (threshold + 1).times do
+          client.handle("AUTH PLAIN #{invalid_auth}")
+        end
+
+        # The increment_error_count("ip-blocked") is called internally
+        # We verify by checking that subsequent attempts are blocked
+        response = client.handle("AUTH PLAIN")
+        expect(response).to eq("421 Too many authentication failures. Try again later.")
+      end
+    end
+
+    describe "different IPs are tracked separately" do
+      let(:ip_address_2) { "192.168.1.101" }
+      let(:client2) { described_class.new(ip_address_2) }
+      let(:invalid_auth) { Base64.encode64("user\0wrongpass") }
+
+      before do
+        client2.handle("HELO test.example.com")
+      end
+
+      it "does not block IP2 when IP1 is blocked" do
+        # Block IP1
+        threshold.times do
+          client.handle("AUTH PLAIN #{invalid_auth}")
+        end
+
+        # IP1 should be blocked
+        response1 = client.handle("AUTH PLAIN")
+        expect(response1).to eq("421 Too many authentication failures. Try again later.")
+
+        # IP2 should not be blocked
+        response2 = client2.handle("AUTH PLAIN #{invalid_auth}")
+        expect(response2).to eq("535 Invalid credential")
+      end
+    end
+
+    describe "logging" do
+      let(:invalid_auth) { Base64.encode64("user\0wrongpass") }
+
+      it "logs when IP is blocked" do
+        allow(client).to receive(:logger).and_return(double("logger").as_null_object)
+
+        threshold.times do
+          client.handle("AUTH PLAIN #{invalid_auth}")
+        end
+
+        expect(client.logger).to have_received(:warn).with(/IP #{ip_address} blocked after #{threshold} failed/)
+      end
+
+      it "logs block message on subsequent attempts" do
+        # Block the IP
+        threshold.times do
+          client.handle("AUTH PLAIN #{invalid_auth}")
+        end
+
+        # Create new client with same IP
+        new_client = described_class.new(ip_address)
+        new_client.handle("HELO test.example.com")
+
+        allow(new_client).to receive(:logger).and_return(double("logger").as_null_object)
+
+        new_client.handle("AUTH PLAIN")
+
+        expect(new_client.logger).to have_received(:warn).with(/Authentication blocked for #{ip_address} - too many failed attempts/)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This commit implements a comprehensive system to protect against brute force attacks on SMTP authentication by automatically blocking IPs after repeated failed authentication attempts.

Features:
- Automatic IP blocking after X failed auth attempts (default: 5, configurable)
- Configurable block duration Y minutes (default: 120, configurable)
- Blocks persist across all SMTP auth methods (PLAIN, LOGIN, CRAM-MD5)
- Counter resets automatically on successful authentication
- Admin web dashboard to view, search, and manage blocked IPs
- Manual block/unblock capabilities for individual or all IPs
- Prometheus metrics integration for monitoring
- Detailed logging for security auditing

Technical Implementation:
- AuthFailureTracker class manages blocking logic using Rails.cache
- SHA-256 hashed cache keys for security
- Efficient indexing system for listing blocked IPs
- RESTful admin routes for IP management
- HAML-based responsive UI integrated with existing admin interface

Testing:
- 39 unit tests for AuthFailureTracker
- 14 integration tests for SMTP client auth blocking
- 7 controller tests for admin dashboard
- All 60 new tests passing

Configuration (via postal.yml or environment variables):
- smtp_server.auth_failure_threshold (default: 5)
- smtp_server.auth_failure_block_duration (default: 120 minutes)

Documentation:
- Complete user guide (doc/SMTP_AUTH_BLOCKING.md)
- Configuration examples for various security levels
- Technical documentation for developers
- Updated main configuration documentation

Files Modified:
- app/lib/smtp_server/client.rb - Integrated blocking checks
- app/views/layouts/application.html.haml - Added menu link
- config/routes.rb - Added admin routes
- lib/postal/config_schema.rb - Added configuration options
- doc/config/configuration.md - Documented new feature

Files Created:
- app/lib/smtp_server/auth_failure_tracker.rb (323 lines)
- app/controllers/admin_blocked_ips_controller.rb (74 lines)
- app/views/admin_blocked_ips/index.html.haml (118 lines)
- 3 comprehensive test files (520+ lines)
- 3 documentation files