### PR TITLE
Replica: Add priority field to server  

### DIFF
--- a/app/lib/worker/jobs/process_queued_messages_job.rb
+++ b/app/lib/worker/jobs/process_queued_messages_job.rb
@@ -46,12 +46,12 @@ module Worker
       # @return [void]
       def lock_message_for_processing
         QueuedMessage.joins(:server)
-                    .where(ip_address_id: [nil, @ip_addresses])
-                    .where(locked_by: nil, locked_at: nil)
-                    .ready_with_delayed_retry
-                    .order("servers.priority DESC, queued_messages.id ASC")
-                    .limit(1)
-                    .update_all(locked_by: @locker, locked_at: @lock_time)
+                     .where(ip_address_id: [nil, @ip_addresses])
+                     .where(locked_by: nil, locked_at: nil)
+                     .ready_with_delayed_retry
+                     .order("servers.priority DESC, queued_messages.id ASC")
+                     .limit(1)
+                     .update_all(locked_by: @locker, locked_at: @lock_time)
       end
 
       # Get a full list of all messages which we can process (i.e. those which have just


### PR DESCRIPTION
Questa PR replica la PR originale: https://github.com/postalserver/postal/pull/3446

**Autore originale:** @amirhasanzadehpy
**Branch originale:** `feature/server-priority-queue`
**Repository originale:** QueraTeam/postal

---

This introduces a server-level priority system to allow for more granular control over the message queue. By assigning a numerical priority to each mail server (with a higher number indicating higher priority), administrators can ensure that time-sensitive transactional emails are processed ahead of bulk newsletters or other less critical mail. This change modifies the message dequeuing logic to sort by server priority before the message ID, ensuring that all high-priority messages are sent first, while maintaining a fair first-in, first-out order for messages of the same priority. The feature is implemented with a default priority of 0 for all existing and new servers, making it a non-disruptive change that can be optionally configured after deployment.